### PR TITLE
feat: add  adapter tests framwork and 4 new adapter tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,30 @@
 [profile.default]
 src = "contracts/8"
 out = "artifacts"
+test = "test"
 
 evm_version = "cancun"
 fs_permissions = [{access = "read-write", path = "./"}]
+
+[rpc_endpoints]
+arb = "https://arb1.arbitrum.io/rpc"
+avax = "https://rpc.ankr.com/avalanche"
+base = "https://mainnet.base.org"
+bsc = "https://bsc.rpc.blxrbdn.com"
+conflux = "https://evm.confluxrpc.com"
+cro = "https://evm-cronos.crypto.org"
+eth = "https://eth-mainnet.public.blastapi.io"
+ethw = "https://mainnet.ethereumpow.org"
+flare = "https://flare-api.flare.network/ext/C/rpc"
+ftm = "https://rpc.ankr.com/fantom"
+linea = "https://1rpc.io/linea"
+manta = "https://pacific-rpc.manta.network"
+mantle = "https://rpc.mantle.xyz"
+metis = "https://andromeda.metis.io/?owner=1088"
+mode = "https://mainnet.mode.network"
+okc = "http://35.72.176.238:26659"
+op = "https://optimism-mainnet.public.blastapi.io"
+polygon = "https://polygon-mainnet.public.blastapi.io"
+polyzkevm = "https://zkevm-rpc.com"
+scroll = "https://rpc.scroll.io"
+sonic = "https://rpc.soniclabs.com"

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,3 +3,4 @@
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
+@okxlabs/=contracts/8

--- a/test/adapter/base/AaveV3StaticATokenAdapter.t.sol
+++ b/test/adapter/base/AaveV3StaticATokenAdapter.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.24;
+
+import {AaveV3StaticATokenAdapter} from "@okxlabs/adapter/AaveV3StaticATokenAdapter.sol";
+import {AbstractAdapterTest} from "../common/AbstractAdapterTest.t.sol";
+
+/**
+ * @title AaveV3StaticATokenAdapterTest
+ * @dev Test for Aave V3 Static aToken adapter
+ * @dev Tests conversions between Static aTokens, aTokens, and underlying tokens
+ * @dev Uses "eth" network identifier from foundry.toml
+ */
+contract AaveV3StaticATokenAdapterTest is AbstractAdapterTest {
+    
+    // Token addresses on Ethereum mainnet
+    address constant STATA_ETH_USDT = 0x862c57d48becB45583AEbA3f489696D22466Ca1b; // Static aToken (pool)
+    address constant AETH_USDT = 0x23878914EFE38d27C4D67Ab83ed1b93A74D4086a; // aToken
+    address constant ETH_USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // Underlying USDT
+    
+    /**
+     * @dev Create AaveV3StaticAToken adapter
+     */
+    function createCustomAdapter() internal override returns (address) {
+        return address(new AaveV3StaticATokenAdapter());
+    }
+    
+    /**
+     * @dev Define test cases for Aave V3 Static aToken conversions
+     */
+    function getSwapTestCases() internal pure override returns (SwapTestCase[] memory) {
+        SwapTestCase[] memory cases = new SwapTestCase[](4);
+        
+        // Test 1: Static aToken to underlying token (stataETHUSDT → USDT)
+        cases[0] = SwapTestCase({
+            networkId: "eth", // Uses ETH network from foundry.toml
+            forkBlock: 20775914, // Latest block
+            fromToken: STATA_ETH_USDT,
+            toToken: ETH_USDT,
+            pool: STATA_ETH_USDT,
+            amount: 1000000, // 1 USDT (6 decimals)
+            expectedOutput: 0, // Dynamic
+            sellBase: true,
+            description: "stataETHUSDT to USDT on ETH",
+            moreInfo: abi.encode(STATA_ETH_USDT, ETH_USDT)
+        });
+        
+        // Test 2: Static aToken to aToken (stataETHUSDT → aETHUSDT)
+        cases[1] = SwapTestCase({
+            networkId: "eth",
+            forkBlock: 20775914,
+            fromToken: STATA_ETH_USDT,
+            toToken: AETH_USDT,
+            pool: STATA_ETH_USDT,
+            amount: 1000000,
+            expectedOutput: 0,
+            sellBase: true,
+            description: "stataETHUSDT to aETHUSDT on ETH",
+            moreInfo: abi.encode(STATA_ETH_USDT, AETH_USDT)
+        });
+        
+        // Test 3: Underlying token to Static aToken (USDT → stataETHUSDT)
+        cases[2] = SwapTestCase({
+            networkId: "eth",
+            forkBlock: 20775914,
+            fromToken: ETH_USDT,
+            toToken: STATA_ETH_USDT,
+            pool: STATA_ETH_USDT,
+            amount: 1000000,
+            expectedOutput: 0,
+            sellBase: false, // Use sellQuote for variety
+            description: "USDT to stataETHUSDT on ETH",
+            moreInfo: abi.encode(ETH_USDT, STATA_ETH_USDT)
+        });
+        
+        // Test 4: aToken to Static aToken (aETHUSDT → stataETHUSDT)
+        cases[3] = SwapTestCase({
+            networkId: "eth",
+            forkBlock: 20775914,
+            fromToken: AETH_USDT,
+            toToken: STATA_ETH_USDT,
+            pool: STATA_ETH_USDT,
+            amount: 1000000,
+            expectedOutput: 0,
+            sellBase: false,
+            description: "aETHUSDT to stataETHUSDT on ETH",
+            moreInfo: abi.encode(AETH_USDT, STATA_ETH_USDT)
+        });
+        
+        return cases;
+    }
+} 

--- a/test/adapter/base/AgniFinanceAdapter.t.sol
+++ b/test/adapter/base/AgniFinanceAdapter.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.24;
+
+import {AgniFinanceAdapter} from "@okxlabs/adapter/AgniFinanceAdapter.sol";
+import {AbstractAdapterTest} from "../common/AbstractAdapterTest.t.sol";
+
+/**
+ * @title AgniFinanceAdapterTest
+ * @dev Test for AgniFinance adapter (UniswapV3-style DEX on Mantle)
+ * @dev Tests token swaps on AgniFinance pools
+ * @dev Uses "mantle" network identifier from foundry.toml
+ */
+contract AgniFinanceAdapterTest is AbstractAdapterTest {
+    
+    // Token addresses on Mantle network
+    address constant WMNT = 0x78c1b0C915c4FAA5FffA6CAbf0219DA63d7f4cb8;
+    address constant WETH = 0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111;
+    address constant USDT = 0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE;
+    
+    // Pool addresses
+    address constant WMNT_USDT = 0xD08C50F7E69e9aeb2867DefF4A8053d9A855e26A;
+    address constant WETH_USDT = 0x628f7131CF43e88EBe3921Ae78C4bA0C31872bd4;
+    
+    /**
+     * @dev Create AgniFinance adapter
+     */
+    function createCustomAdapter() internal override returns (address) {
+        return address(new AgniFinanceAdapter(payable(WMNT)));
+    }
+    
+    /**
+     * @dev Define test cases for AgniFinance swaps
+     */
+    function getSwapTestCases() internal pure override returns (SwapTestCase[] memory) {
+        SwapTestCase[] memory cases = new SwapTestCase[](4);
+        
+        // Test 1: WMNT to USDT
+        // //https://explorer.mantle.xyz/tx/0x49e745b9582d202b744a140c3a7e6aa8cd4a2bb2a282609b413696ddd899eebe
+        cases[0] = SwapTestCase({
+            networkId: "mantle", // Uses Mantle network from foundry.toml
+            forkBlock: 62825725, // Block before the transaction
+            fromToken: WMNT,
+            toToken: USDT,
+            pool: WMNT_USDT,
+            amount: 0.415 * 10**18, // 0.415 WMNT
+            expectedOutput: 0.504974 * 10**6,
+            sellBase: true,
+            description: "WMNT to USDT on Mantle",
+            moreInfo: abi.encode(uint160(0), abi.encode(WMNT, USDT))
+        });
+        
+        // Test 2: USDT to WMNT
+        cases[1] = SwapTestCase({
+            networkId: "mantle",
+            forkBlock: 62825725,
+            fromToken: USDT,
+            toToken: WMNT,
+            pool: WMNT_USDT,
+            amount: 1000000, // 1 USDT (6 decimals)
+            expectedOutput: 0,
+            sellBase: false, // USDT is quote token
+            description: "USDT to WMNT on Mantle",
+            moreInfo: abi.encode(uint160(0), abi.encode(USDT, WMNT))
+        });
+        
+        // Test 3: WETH to USDT
+        cases[2] = SwapTestCase({
+            networkId: "mantle",
+            forkBlock: 62825725,
+            fromToken: WETH,
+            toToken: USDT,
+            pool: WETH_USDT,
+            amount: 1 ether, // 1 WETH
+            expectedOutput: 0,
+            sellBase: true,
+            description: "WETH to USDT on Mantle",
+            moreInfo: abi.encode(uint160(0), abi.encode(WETH, USDT))
+        });
+        
+        // Test 4: USDT to WETH
+        cases[3] = SwapTestCase({
+            networkId: "mantle",
+            forkBlock: 62825725,
+            fromToken: USDT,
+            toToken: WETH,
+            pool: WETH_USDT,
+            amount: 3000 * 10**6, // 3000 USDT
+            expectedOutput: 0,
+            sellBase: false,
+            description: "USDT to WETH on Mantle",
+            moreInfo: abi.encode(uint160(0), abi.encode(USDT, WETH))
+        });
+        
+        return cases;
+    }
+} 

--- a/test/adapter/base/AlienBaseV3Adapter.t.sol
+++ b/test/adapter/base/AlienBaseV3Adapter.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.24;
+
+import {AlienBaseV3Adapter} from "@okxlabs/adapter/AlienBaseV3Adapter.sol";
+import {AbstractAdapterTest} from "../common/AbstractAdapterTest.t.sol";
+
+/**
+ * @title AlienBaseV3AdapterTest
+ * @dev Test for AlienBase V3 adapter (Uniswap V3 style DEX on Base)
+ * @dev Tests token swaps on AlienBase V3 pools
+ * @dev Uses "base" network identifier from foundry.toml
+ */
+contract AlienBaseV3AdapterTest is AbstractAdapterTest {
+    
+    // Token addresses on Base network
+    address constant WETH = 0x4200000000000000000000000000000000000006;
+    address constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    
+    // Pool address
+    address constant WETH_USDC_POOL = 0xB27f110571c96B8271d91ad42D33A391A75E6030;
+    
+    /**
+     * @dev Create AlienBaseV3 adapter
+     */
+    function createCustomAdapter() internal override returns (address) {
+        return address(new AlienBaseV3Adapter(payable(WETH)));
+    }
+    
+    /**
+     * @dev Define test cases for AlienBase V3 swaps
+     */
+    function getSwapTestCases() internal pure override returns (SwapTestCase[] memory) {
+        SwapTestCase[] memory cases = new SwapTestCase[](2);
+        
+        // Test 1: WETH to USDC
+        // https://basescan.org/tx/0xc83216c8605b73c006a951cbd1a982086bdc4321e1f1756f9a7d0b35a8288ca0
+        cases[0] = SwapTestCase({
+            networkId: "base",
+            forkBlock: 21693942,
+            fromToken: WETH,
+            toToken: USDC,
+            pool: WETH_USDC_POOL,
+            amount: 0.046502901914085561 * 10**18, // ~0.046502 WETH
+            expectedOutput: 121.605458 * 10**6, // actual output is 121.788068 USDC, but we can't get the exact output because of the rounding error
+            sellBase: false, // WETH is quote in this context
+            description: "WETH to USDC on Base", 
+            moreInfo: abi.encode(uint160(0), abi.encode(WETH, USDC, uint24(0)))
+        });
+
+        // Test 2: USDC to WETH (based on original test)
+        cases[1] = SwapTestCase({
+            networkId: "base", // Uses Base network from foundry.toml
+            forkBlock: 21693941, // Block from original test
+            fromToken: USDC,
+            toToken: WETH,
+            pool: WETH_USDC_POOL,
+            amount: 121788068, // 121.788068 USDC (6 decimals)
+            expectedOutput: 0, // Dynamic
+            sellBase: true, // USDC is base in this context
+            description: "USDC to WETH on Base",
+            moreInfo: abi.encode(uint160(0), abi.encode(USDC, WETH, uint24(0)))
+        });
+        
+        return cases;
+    }
+} 

--- a/test/adapter/base/AllBridgeAdapter.t.sol
+++ b/test/adapter/base/AllBridgeAdapter.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.24;
+
+import {AllBridgeAdapter} from "@okxlabs/adapter/AllBridgeAdapter.sol";
+import {AbstractAdapterTest} from "../common/AbstractAdapterTest.t.sol";
+
+/**
+ * @title AllBridgeAdapterTest
+ * @dev Test for AllBridge adapter (USDC/USDT stablecoin bridge)
+ * @dev Tests token swaps between USDC and USDT on Ethereum
+ * @dev Uses "eth" network identifier from foundry.toml
+ */
+contract AllBridgeAdapterTest is AbstractAdapterTest {
+    
+    // Token addresses on Ethereum mainnet
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    
+    // AllBridge router and pool
+    address constant ALLBRIDGE_ROUTER = 0x609c690e8F7D68a59885c9132e812eEbDaAf0c9e;
+    address constant USDT_LP = 0x7DBF07Ad92Ed4e26D5511b4F285508eBF174135D; // Pool address
+    
+    /**
+     * @dev Create AllBridge adapter
+     */
+    function createCustomAdapter() internal override returns (address) {
+        return address(new AllBridgeAdapter(ALLBRIDGE_ROUTER));
+    }
+    
+    /**
+     * @dev Define test cases for AllBridge swaps
+     */
+    function getSwapTestCases() internal pure override returns (SwapTestCase[] memory) {
+        SwapTestCase[] memory cases = new SwapTestCase[](2);
+        
+        // Test 1: USDC to USDT
+        cases[0] = SwapTestCase({
+            networkId: "eth", // Uses ETH network from foundry.toml
+            forkBlock: 0, // Use latest block
+            fromToken: USDC,
+            toToken: USDT,
+            pool: USDT_LP,
+            amount: 1 * 10**6, // 1 USDC (6 decimals)
+            expectedOutput: 0, // Dynamic
+            sellBase: true, // USDC as base
+            description: "USDC to USDT via AllBridge on ETH",
+            moreInfo: abi.encode(bytes32(uint256(uint160(USDC))), bytes32(uint256(uint160(USDT))))
+        });
+        
+        // Test 2: USDT to USDC  
+        cases[1] = SwapTestCase({
+            networkId: "eth",
+            forkBlock: 0,
+            fromToken: USDT,
+            toToken: USDC,
+            pool: USDT_LP,
+            amount: 1 * 10**6, // 1 USDT (6 decimals)
+            expectedOutput: 0,
+            sellBase: false, // USDT as quote
+            description: "USDT to USDC via AllBridge on ETH",
+            moreInfo: abi.encode(bytes32(uint256(uint160(USDT))), bytes32(uint256(uint160(USDC))))
+        });
+        
+        return cases;
+    }
+} 

--- a/test/adapter/common/AbstractAdapterTest.t.sol
+++ b/test/adapter/common/AbstractAdapterTest.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@okxlabs/interfaces/IERC20.sol";
+import {SpecialToken} from "./SpecialToken.t.sol";
+import {console2} from "forge-std/console2.sol"; // solhint-disable no-console
+
+/**
+ * @title AbstractAdapterTest
+ * @dev Simple base contract for adapter testing
+ * @dev Uses network identifiers from foundry.toml rpc_endpoints
+ */
+abstract contract AbstractAdapterTest is Test {
+    
+    // Simplified swap test case struct using network identifiers
+    struct SwapTestCase {
+        string networkId; // Network identifier from foundry.toml (e.g., "bsc", "eth", "arb")
+        uint256 forkBlock;
+        address fromToken;
+        address toToken;
+        address pool;
+        uint256 amount;
+        uint256 expectedOutput; // expected output (0 for dynamic)
+        bool sellBase;
+        string description;
+        bytes moreInfo; // adapter-specific data
+    }
+    
+    // Network state tracking
+    struct NetworkState {
+        string currentNetworkId;
+        uint256 currentForkBlock;
+        uint256 forkId;
+        bool isActive;
+    }
+    
+    SwapTestCase[] internal testCases;
+    NetworkState internal currentNetwork;
+    address public customAdapter;
+    SpecialToken internal specialToken; // Use SpecialToken instead of standard deal
+    
+    // Events for logging
+    event NetworkSwitch(string from, string to, uint256 blockNumber);
+    event TestCaseStart(uint256 index, string description);
+    event TestCaseComplete(uint256 index, bool success);
+    
+    /**
+     * @dev Abstract functions that must be implemented
+     */
+    function createCustomAdapter() internal virtual returns (address);
+    function getSwapTestCases() internal virtual returns (SwapTestCase[] memory);
+    
+    /**
+     * @dev Simple setup function
+     */
+    function setUp() public virtual {
+        // Initialize SpecialToken
+        
+        // Load test cases
+        SwapTestCase[] memory cases = getSwapTestCases();
+        require(cases.length > 0, "No test cases provided");
+        
+        for (uint256 i = 0; i < cases.length; i++) {
+            testCases.push(cases[i]);
+        }
+    }
+    
+    /**
+     * @dev Run all test cases
+     */
+    function test_AllCases() public {
+        for (uint256 i = 0; i < testCases.length; i++) {
+            _runTestCase(testCases[i], i);
+        }
+    }
+    
+    /**
+     * @dev Run a single test case
+     */
+    function _runTestCase(SwapTestCase memory testCase, uint256 index) internal {
+        emit TestCaseStart(index, testCase.description);
+        console2.log("=== Test Case %s: %s ===", index, testCase.description);
+        
+        bool success = false;
+        
+        try this._executeTestCase(testCase) {
+            success = true;
+            console2.log("[PASS] Test case %s completed successfully", index);
+        } catch Error(string memory reason) {
+            console2.log("[FAIL] Test case %s failed: %s", index, reason);
+        } catch (bytes memory) {
+            console2.log("[FAIL] Test case %s failed with low-level error", index);
+        }
+        
+        emit TestCaseComplete(index, success);
+        require(success, string(abi.encodePacked("Test case ", vm.toString(index), " failed")));
+    }
+    
+    /**
+     * @dev Execute test case (external for try-catch)
+     */
+    function _executeTestCase(SwapTestCase memory testCase) external {
+        // Switch to test case network using network identifier
+        _switchToNetwork(testCase.networkId, testCase.forkBlock);
+        
+        // Execute swap
+        _performSwap(testCase);
+    }
+    
+    /**
+     * @dev Core swap execution logic
+     */
+    function _performSwap(SwapTestCase memory testCase) internal {
+        specialToken = new SpecialToken();
+        // Create adapter
+        customAdapter = createCustomAdapter();
+        // Setup tokens
+        if (specialToken.wealthyHolders(testCase.fromToken) != address(0)) {
+            // Special token transfer whale
+            specialToken.specialDeal(testCase.fromToken, address(customAdapter), testCase.amount);
+        } else {
+            deal(testCase.fromToken, address(customAdapter), testCase.amount);
+        }
+        
+        // Record initial balances
+        uint256 initialFromBalance = IERC20(testCase.fromToken).balanceOf(address(customAdapter));
+        uint256 initialToBalance = IERC20(testCase.toToken).balanceOf(address(this)); // Output goes to test contract
+        
+        // Execute swap
+        bool success;
+        bytes memory returnData;
+        
+        if (testCase.sellBase) {
+            (success, returnData) = customAdapter.call(
+                abi.encodeWithSignature(
+                    "sellBase(address,address,bytes)",
+                    address(this),
+                    testCase.pool,
+                    testCase.moreInfo
+                )
+            );
+        } else {
+            (success, returnData) = customAdapter.call(
+                abi.encodeWithSignature(
+                    "sellQuote(address,address,bytes)",
+                    address(this),
+                    testCase.pool,
+                    testCase.moreInfo
+                )
+            );
+        }
+        
+        require(success, string(abi.encodePacked("Swap failed: ", returnData)));
+        
+        // Check results
+        uint256 finalFromBalance = IERC20(testCase.fromToken).balanceOf(address(customAdapter));
+        uint256 finalToBalance = IERC20(testCase.toToken).balanceOf(address(this)); // Output is in test contract
+        
+        uint256 outputReceived = finalToBalance - initialToBalance;
+        
+        // Check expected output if specified
+        if (testCase.expectedOutput > 0) {
+            require(outputReceived == testCase.expectedOutput, "Output amount mismatch");
+        }
+        // Check from token balance
+        require(finalFromBalance == initialFromBalance - testCase.amount, "From token balance mismatch");
+                
+        // Verify we received output tokens
+        require(outputReceived > 0, "No output tokens received");
+    }
+    
+    /**
+     * @dev Switch to a specific network using network identifier
+     * @param networkId Network identifier from foundry.toml (e.g., "bsc", "eth", "arb")
+     * @param forkBlock Block number to fork at
+     */
+    function _switchToNetwork(string memory networkId, uint256 forkBlock) internal {
+        // Skip if already on correct network
+        if (currentNetwork.isActive && 
+            keccak256(bytes(currentNetwork.currentNetworkId)) == keccak256(bytes(networkId)) &&
+            currentNetwork.currentForkBlock == forkBlock) {
+            return;
+        }
+        
+        // Log network switch
+        if (currentNetwork.isActive) {
+            emit NetworkSwitch(currentNetwork.currentNetworkId, networkId, forkBlock);
+        }
+        
+        // Create new fork using network identifier
+        // This will automatically use the RPC URL from foundry.toml [rpc_endpoints]
+        uint256 forkId;
+        if (forkBlock == 0) {
+            forkId = vm.createSelectFork(networkId);
+        } else {
+            forkId = vm.createSelectFork(networkId, forkBlock);
+        }
+        
+        // Update network state
+        currentNetwork = NetworkState({
+            currentNetworkId: networkId,
+            currentForkBlock: forkBlock,
+            forkId: forkId,
+            isActive: true
+        });
+        
+        // console2.log("Switched to network: %s at block %s", networkId, forkBlock);
+    }
+    
+    /**
+     * @dev Get current network information
+     */
+    function getCurrentNetwork() external view returns (NetworkState memory) {
+        return currentNetwork;
+    }
+    
+    /**
+     * @dev Helper function to add test cases dynamically
+     */
+    function addTestCase(SwapTestCase memory testCase) internal {
+        testCases.push(testCase);
+    }
+    
+    /**
+     * @dev Add wealthy holder for custom tokens not in SpecialToken default list
+     * @param token Token address
+     * @param holder Wealthy holder address
+     */
+    function addWealthyHolder(address token, address holder) external {
+        specialToken.addWealthyHolder(token, holder);
+    }
+    
+    /**
+     * @dev Check if token has wealthy holders configured
+     * @param token Token address
+     * @return True if wealthy holders exist
+     */
+    function hasWealthyHolders(address token) external view returns (bool) {
+        return specialToken.hasWealthyHolders(token);
+    }
+} 

--- a/test/adapter/common/SpecialToken.t.sol
+++ b/test/adapter/common/SpecialToken.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@okxlabs/interfaces/IERC20.sol";
+
+/**
+ * @title SpecialToken
+ * @dev Helper contract for dealing tokens via on-chain transfers instead of stdStorage
+ * @dev Maintains a mapping of token addresses to known wealthy holders
+ */
+contract SpecialToken is Test {
+    
+    // 1 to 1 mapping of token address to wealthy holder address
+    mapping(address => address) public wealthyHolders;
+    
+    constructor() {
+        _setupWealthyHolders();
+    }
+    
+    /**
+     * @dev Setup known wealthy holders for common tokens
+     */
+    function _setupWealthyHolders() internal {
+        // Aave aUSDT
+        address AETH_USDT = 0x23878914EFE38d27C4D67Ab83ed1b93A74D4086a;
+        wealthyHolders[AETH_USDT] = 0x18709E89BD403F470088aBDAcEbE86CC60dda12e; // Aave Collector
+    }
+    
+    /**
+     * @dev Add wealthy holder for a token
+     * @param token The token address
+     * @param holder The wealthy holder address
+     */
+    function addWealthyHolder(address token, address holder) external {
+        wealthyHolders[token] = holder;
+    }
+    
+    /**
+     * @dev Check if a token has a wealthy holder configured
+     * @param token The token address
+     * @return true if the token has a wealthy holder
+     */
+    function hasWealthyHolders(address token) external view returns (bool) {
+        return wealthyHolders[token] != address(0);
+    }
+    
+    /**
+     * @dev Deal tokens to a recipient via on-chain transfer
+     * @param token The token address
+     * @param to The recipient address  
+     * @param amount The amount to transfer
+     */
+    function specialDeal(address token, address to, uint256 amount) external {
+        
+        address holder = wealthyHolders[token];
+        uint256 balance = IERC20(token).balanceOf(holder);
+            
+        if (balance >= amount) {
+            vm.prank(holder);
+            try IERC20(token).transfer(to, amount) returns (bool success) {
+                if (success) {
+                    return; // Successfully transferred
+                }
+            } catch {
+                revert("SpecialToken: Unable to transfer tokens - insufficient balance or transfer failed");
+            }
+        }
+    }
+} 


### PR DESCRIPTION
- Updated foundry.toml to include multiple RPC endpoints for various networks.
- Added new test files for AaveV3StaticATokenAdapter, AgniFinanceAdapter, AlienBaseV3Adapter, AllBridgeAdapter, and a common AbstractAdapterTest.
- Introduced SpecialToken contract to facilitate on-chain token transfers for testing.

This update improves multi-chain support and testing capabilities for the adapters.