### PR TITLE
feat(test): add expectRevert support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ fs_permissions = [{access = "read-write", path = "./"}]
 arb = "https://arb1.arbitrum.io/rpc"
 avax = "https://rpc.ankr.com/avalanche"
 base = "https://mainnet.base.org"
-bsc = "https://bsc.rpc.blxrbdn.com"
+bsc = "https://bnb-mainnet.g.alchemy.com/public"
 conflux = "https://evm.confluxrpc.com"
 cro = "https://evm-cronos.crypto.org"
 eth = "https://eth-mainnet.public.blastapi.io"

--- a/test/adapter/base/AaveV3StaticATokenAdapter.t.sol
+++ b/test/adapter/base/AaveV3StaticATokenAdapter.t.sol
@@ -40,6 +40,7 @@ contract AaveV3StaticATokenAdapterTest is AbstractAdapterTest {
             amount: 1000000, // 1 USDT (6 decimals)
             expectedOutput: 0, // Dynamic
             sellBase: true,
+            expectRevert: false,
             description: "stataETHUSDT to USDT on ETH",
             moreInfo: abi.encode(STATA_ETH_USDT, ETH_USDT)
         });
@@ -54,6 +55,7 @@ contract AaveV3StaticATokenAdapterTest is AbstractAdapterTest {
             amount: 1000000,
             expectedOutput: 0,
             sellBase: true,
+            expectRevert: false,
             description: "stataETHUSDT to aETHUSDT on ETH",
             moreInfo: abi.encode(STATA_ETH_USDT, AETH_USDT)
         });
@@ -68,6 +70,7 @@ contract AaveV3StaticATokenAdapterTest is AbstractAdapterTest {
             amount: 1000000,
             expectedOutput: 0,
             sellBase: false, // Use sellQuote for variety
+            expectRevert: false,
             description: "USDT to stataETHUSDT on ETH",
             moreInfo: abi.encode(ETH_USDT, STATA_ETH_USDT)
         });
@@ -82,6 +85,7 @@ contract AaveV3StaticATokenAdapterTest is AbstractAdapterTest {
             amount: 1000000,
             expectedOutput: 0,
             sellBase: false,
+            expectRevert: false,
             description: "aETHUSDT to stataETHUSDT on ETH",
             moreInfo: abi.encode(AETH_USDT, STATA_ETH_USDT)
         });

--- a/test/adapter/base/AgniFinanceAdapter.t.sol
+++ b/test/adapter/base/AgniFinanceAdapter.t.sol
@@ -45,6 +45,7 @@ contract AgniFinanceAdapterTest is AbstractAdapterTest {
             amount: 0.415 * 10**18, // 0.415 WMNT
             expectedOutput: 0.504974 * 10**6,
             sellBase: true,
+            expectRevert: false,
             description: "WMNT to USDT on Mantle",
             moreInfo: abi.encode(uint160(0), abi.encode(WMNT, USDT))
         });
@@ -59,6 +60,7 @@ contract AgniFinanceAdapterTest is AbstractAdapterTest {
             amount: 1000000, // 1 USDT (6 decimals)
             expectedOutput: 0,
             sellBase: false, // USDT is quote token
+            expectRevert: false,
             description: "USDT to WMNT on Mantle",
             moreInfo: abi.encode(uint160(0), abi.encode(USDT, WMNT))
         });
@@ -73,6 +75,7 @@ contract AgniFinanceAdapterTest is AbstractAdapterTest {
             amount: 1 ether, // 1 WETH
             expectedOutput: 0,
             sellBase: true,
+            expectRevert: false,
             description: "WETH to USDT on Mantle",
             moreInfo: abi.encode(uint160(0), abi.encode(WETH, USDT))
         });
@@ -87,6 +90,7 @@ contract AgniFinanceAdapterTest is AbstractAdapterTest {
             amount: 3000 * 10**6, // 3000 USDT
             expectedOutput: 0,
             sellBase: false,
+            expectRevert: false,
             description: "USDT to WETH on Mantle",
             moreInfo: abi.encode(uint160(0), abi.encode(USDT, WETH))
         });

--- a/test/adapter/base/AlienBaseV3Adapter.t.sol
+++ b/test/adapter/base/AlienBaseV3Adapter.t.sol
@@ -43,6 +43,7 @@ contract AlienBaseV3AdapterTest is AbstractAdapterTest {
             amount: 0.046502901914085561 * 10**18, // ~0.046502 WETH
             expectedOutput: 121.605458 * 10**6, // actual output is 121.788068 USDC, but we can't get the exact output because of the rounding error
             sellBase: false, // WETH is quote in this context
+            expectRevert: false,
             description: "WETH to USDC on Base", 
             moreInfo: abi.encode(uint160(0), abi.encode(WETH, USDC, uint24(0)))
         });
@@ -57,6 +58,7 @@ contract AlienBaseV3AdapterTest is AbstractAdapterTest {
             amount: 121788068, // 121.788068 USDC (6 decimals)
             expectedOutput: 0, // Dynamic
             sellBase: true, // USDC is base in this context
+            expectRevert: false,
             description: "USDC to WETH on Base",
             moreInfo: abi.encode(uint160(0), abi.encode(USDC, WETH, uint24(0)))
         });

--- a/test/adapter/base/AllBridgeAdapter.t.sol
+++ b/test/adapter/base/AllBridgeAdapter.t.sol
@@ -43,6 +43,7 @@ contract AllBridgeAdapterTest is AbstractAdapterTest {
             amount: 1 * 10**6, // 1 USDC (6 decimals)
             expectedOutput: 0, // Dynamic
             sellBase: true, // USDC as base
+            expectRevert: false,
             description: "USDC to USDT via AllBridge on ETH",
             moreInfo: abi.encode(bytes32(uint256(uint160(USDC))), bytes32(uint256(uint160(USDT))))
         });
@@ -57,6 +58,7 @@ contract AllBridgeAdapterTest is AbstractAdapterTest {
             amount: 1 * 10**6, // 1 USDT (6 decimals)
             expectedOutput: 0,
             sellBase: false, // USDT as quote
+            expectRevert: false,
             description: "USDT to USDC via AllBridge on ETH",
             moreInfo: abi.encode(bytes32(uint256(uint160(USDT))), bytes32(uint256(uint160(USDC))))
         });


### PR DESCRIPTION
# Purpose
Proposal to change `test/adapter/common/AbstractAdapterTest.t.sol` to support test where a revert is expected.

# Changes

## 1. Add field to SwapTestCase Struct
- Add `bool expectRevert` field indicating when a test case should expect the swap to revert
- Field positioned after `sellBase` for logical grouping with other boolean flags

## 2. Update Swap Execution Logic in `_performSwap`
- Add conditional `vm.expectRevert()` call when `testCase.expectRevert` is true
- Uses Foundry's native expectRevert mechanism for proper revert testing
- Placed immediately before the actual swap execution calls

## 3. Update Validation Logic
- **For expected reverts** (`expectRevert: true`):
  - Verify from token balance remains unchanged (no tokens consumed)
  - Verify output tokens received equals zero (no tokens received)
- **For successful swaps** (`expectRevert: false`):
  - Maintain existing validation logic (tokens consumed, output received, etc.)
  - Preserves backward compatibility for all existing tests

## 4. Update Existing Tests
- Update existing tests to match SwapTestCase Struct

# Tests
All tests are passing.

```
bryanang@Bryan-Ang-Huai-Ens-MacBook-Pro DEX-Router-EVM-V1 % forge test 
[⠊] Compiling...
No files changed, compilation skipped

Ran 1 test for test/adapter/base/AgniFinanceAdapter.t.sol:AgniFinanceAdapterTest
[PASS] test_AllCases() (gas: 9586210)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 475.37ms (474.91ms CPU time)

Ran 1 test for test/adapter/base/AaveV3StaticATokenAdapter.t.sol:AaveV3StaticATokenAdapterTest
[PASS] test_AllCases() (gas: 9050336)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 511.69ms (511.22ms CPU time)

Ran 1 test for test/adapter/base/AlienBaseV3Adapter.t.sol:AlienBaseV3AdapterTest
[PASS] test_AllCases() (gas: 5056439)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.96s (1.96s CPU time)

Ran 1 test for test/adapter/base/AllBridgeAdapter.t.sol:AllBridgeAdapterTest
[PASS] test_AllCases() (gas: 4140805)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.68s (3.67s CPU time)

Ran 4 test suites in 3.68s (6.62s CPU time): 4 tests passed, 0 failed, 0 skipped (4 total tests)
```