### PR TITLE
Release v1.0.6-dag: Update DexRouter related files

### DIFF
--- a/contracts/8/UnxswapV3Router.sol
+++ b/contracts/8/UnxswapV3Router.sol
@@ -16,7 +16,7 @@ contract UnxswapV3Router is IUniswapV3SwapCallback, CommonUtils {
 
     bytes32 private constant _POOL_INIT_CODE_HASH =
         0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54; // Pool init code hash
-    bytes32 private constant _FF_FACTORY = 0xff1F98431c8aD98523631AE4a59f267346ea31F9840000000000000000000000; // Factory address
+    bytes32 private constant _FF_FACTORY = 0x0000000000000000000000000000000000000000000000000000000000000000; // Factory address
     // concatenation of token0(), token1() fee(), transfer() and claimTokens() selectors
     bytes32 private constant _SELECTORS =
         0x0dfe1681d21220a7ddca3f43a9059cbb0a5ea466000000000000000000000000;

--- a/contracts/8/libraries/CommonUtils.sol
+++ b/contracts/8/libraries/CommonUtils.sol
@@ -38,7 +38,7 @@ abstract contract CommonUtils {
     // CRO:     5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23
     // CFX:     14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b
     // POLYZK   4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9
-    address public constant _WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant _WETH = 0x7Bf88d2c0e32dE92CdaF2D43CcDc23e8Edfd5990;
     // address public constant _WETH = 0x5FbDB2315678afecb367f032d93F642f64180aa3;    // hardhat1
     // address public constant _WETH = 0x707531c9999AaeF9232C8FEfBA31FBa4cB78d84a;    // hardhat2
 
@@ -73,7 +73,7 @@ abstract contract CommonUtils {
     // CRO:     40aA958dd87FC8305b97f2BA922CDdCa374bcD7f
     // CFX:     40aA958dd87FC8305b97f2BA922CDdCa374bcD7f
     // POLYZK   d2F0aC2012C8433F235c8e5e97F2368197DD06C7
-    address public constant _WNATIVE_RELAY = 0x5703B683c7F928b721CA95Da988d73a3299d4757;
+    address public constant _WNATIVE_RELAY = 0x4D8d82F269A2704867b6cAf58d6e8389e3066eC9;
     // address public constant _WNATIVE_RELAY = 0x0B306BF915C4d645ff596e518fAf3F9669b97016;   // hardhat1
     // address public constant _WNATIVE_RELAY = 0x6A47346e722937B60Df7a1149168c0E76DD6520f;   // hardhat2
 


### PR DESCRIPTION
## Release v1.0.6-dag

This PR includes updates to DexRouter related files only (no adapter changes):

### Changes:
- Updated `contracts/8/UnxswapV3Router.sol`
- Updated `contracts/8/libraries/CommonUtils.sol`

### Version:
- Tag: v1.0.6-dag

### Note:
This release does not include adapter-related changes.