### PR TITLE
refactor: enhance DagRouter and DexRouter for commission handling and…

### DIFF
--- a/contracts/8/DagRouter.sol
+++ b/contracts/8/DagRouter.sol
@@ -47,7 +47,13 @@ abstract contract DagRouter is CommonLib {
         }
 
         // 2. execute dag swap
-        _exeDagSwap(payer, receiver, refundTo, _baseRequest.fromTokenAmount, IERC20(_baseRequest.toToken).isETH(), paths);
+        // For BY_INVEST mode, the fromTokenAmount still needs to be fromToken balance to keep consistent with smartSwapByInvestWithRefund.
+        // In later version, the scaling of fromTokenAmount will be completed by the earn contract, then we will remove this logic.
+        uint256 firstNodeBalance = _baseRequest.fromTokenAmount;
+        if (paths[0].fromToken & _TRANSFER_MODE_MASK == _MODE_BY_INVEST) {
+            firstNodeBalance = IERC20(firstNodeToken).balanceOf(address(this));
+        }
+        _exeDagSwap(payer, receiver, refundTo, firstNodeBalance, IERC20(_baseRequest.toToken).isETH(), paths);
 
         // 3. transfer tokens to receiver
         _transferTokenToUser(_baseRequest.toToken, receiver);

--- a/contracts/8/interfaces/AbstractCommissionLib.sol
+++ b/contracts/8/interfaces/AbstractCommissionLib.sol
@@ -6,21 +6,35 @@ abstract contract AbstractCommissionLib {
     struct CommissionInfo {
         bool isFromTokenCommission; //0x00
         bool isToTokenCommission; //0x20
-        uint256 commissionRate; //0x40
-        address refererAddress; //0x60
-        address token; //0x80
-        uint256 commissionRate2; //0xa0
-        address refererAddress2; //0xc0
-        bool isToBCommission; //0xe0
+        address token; // 0x40
+        uint256 toBCommission; // 0x60, 0 for no commission, 1 for no-toB commission, 2 for toB commission
+        uint256 commissionLength; // 0x80
+        uint256 commissionRate; // 0xa0
+        address referrerAddress; // 0xc0
+        uint256 commissionRate2; // 0xe0
+        address referrerAddress2; // 0x100
+        uint256 commissionRate3; // 0x120
+        address referrerAddress3; // 0x140
+        uint256 commissionRate4; // 0x160
+        address referrerAddress4; // 0x180
+        uint256 commissionRate5; // 0x1a0
+        address referrerAddress5; // 0x1c0
+        uint256 commissionRate6; // 0x1e0
+        address referrerAddress6; // 0x200
+        uint256 commissionRate7; // 0x220
+        address referrerAddress7; // 0x240
+        uint256 commissionRate8; // 0x260
+        address referrerAddress8; // 0x280
     }
 
     struct TrimInfo {
         bool hasTrim; // 0x00
         uint256 trimRate; // 0x20
         address trimAddress; // 0x40
-        uint256 expectAmountOut; // 0x60
-        uint256 chargeRate; // 0x80
-        address chargeAddress; // 0xa0
+        uint256 toBTrim; // 0x60, 0 for no trim, 1 for no-toB trim, 2 for toB trim
+        uint256 expectAmountOut; // 0x80
+        uint256 chargeRate; // 0xa0
+        address chargeAddress; // 0xc0
     }
 
     function _getCommissionAndTrimInfo()

--- a/contracts/8/libraries/CommissionLib.sol
+++ b/contracts/8/libraries/CommissionLib.sol
@@ -18,8 +18,15 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
         0x22220afc2aaa0000000000000000000000000000000000000000000000000000;
     uint256 internal constant TO_TOKEN_COMMISSION_DUAL =
         0x22220afc2bbb0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant FROM_TOKEN_COMMISSION_MULTIPLE =
+        0x88880afc2aaa0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant TO_TOKEN_COMMISSION_MULTIPLE =
+        0x88880afc2bbb0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant _COMMISSION_LENGTH_MASK =
+        0x00ff000000000000000000000000000000000000000000000000000000000000;
     uint256 internal constant _TO_B_COMMISSION_MASK =
         0x8000000000000000000000000000000000000000000000000000000000000000;
+
 
     uint256 internal constant _TRIM_FLAG_MASK =
         0xffffffffffff0000000000000000000000000000000000000000000000000000;
@@ -27,15 +34,16 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
         0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff;
     uint256 internal constant _TRIM_RATE_MASK =
         0x000000000000ffffffffffff0000000000000000000000000000000000000000;
+    uint256 internal constant _TO_B_TRIM_MASK =
+        0x0000000000008000000000000000000000000000000000000000000000000000;
     uint256 internal constant TRIM_FLAG =
         0x7777777711110000000000000000000000000000000000000000000000000000;
     uint256 internal constant TRIM_DUAL_FLAG =
         0x7777777722220000000000000000000000000000000000000000000000000000;
 
     event CommissionAndTrimInfo(
-        uint256 commissionRate1,
-        uint256 commissionRate2,
-        bool isToBCommission,
+        uint256 toBCommission, // 0 for no commission, 1 for no-toB commission, 2 for toB commission
+        uint256 toBTrim, // 0 for no trim, 1 for no-toB trim, 2 for toB trim
         uint256 trimRate,
         uint256 chargeRate
     );
@@ -44,14 +52,16 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
     // event CommissionFromTokenRecord(
     //     address fromTokenAddress,
     //     uint256 commissionAmount,
-    //     address referrerAddress
+    //     address referrerAddress,
+    //     uint256 commissionRate
     // );
 
     // @notice CommissionToTokenRecord is emitted in assembly, commentted out for contract size saving
     // event CommissionToTokenRecord(
     //     address toTokenAddress,
     //     uint256 commissionAmount,
-    //     address referrerAddress
+    //     address referrerAddress,
+    //     uint256 commissionRate
     // );
 
     // @notice PositiveSlippageTrimRecord is emitted in assembly, commentted out for contract size saving
@@ -69,8 +79,12 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
     // );
 
     // set default value can change when need.
+    uint256 internal constant MIN_COMMISSION_MULTIPLE_NUM = 3; // min referrer num for multiple commission
+    uint256 internal constant MAX_COMMISSION_MULTIPLE_NUM = 8; // max referrer num for multiple commission
     uint256 internal constant commissionRateLimit = 30000000;
     uint256 internal constant DENOMINATOR = 10 ** 9;
+    uint256 internal constant NO_TO_B_MODE = 1; // value for no-toB commission and no-toB trim when related calldata exists
+    uint256 internal constant TO_B_MODE = 2; // value for toB commission and toB trim when related calldata exists
     uint256 internal constant WAD = 1 ether;
     uint256 internal constant TRIM_RATE_LIMIT = 100;
     uint256 internal constant TRIM_DENOMINATOR = 1000;
@@ -81,117 +95,216 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
         returns (CommissionInfo memory commissionInfo, TrimInfo memory trimInfo)
     {
         assembly ("memory-safe") {
-            // let freePtr := mload(0x40)
-            // mstore(0x40, add(freePtr, 0x100))
+            function _revertWithReason(m, len) {
+                mstore(
+                    0,
+                    0x08c379a000000000000000000000000000000000000000000000000000000000
+                )
+                mstore(
+                    0x20,
+                    0x0000002000000000000000000000000000000000000000000000000000000000
+                )
+                mstore(0x40, m)
+                revert(0, len)
+            }
+
             let commissionData := calldataload(sub(calldatasize(), 0x20))
             let flag := and(commissionData, _COMMISSION_FLAG_MASK)
-            let isDualreferrers := or(
+            let referrerNum := 0
+            if or(
+                eq(flag, FROM_TOKEN_COMMISSION),
+                eq(flag, TO_TOKEN_COMMISSION)
+            ) {
+                referrerNum := 1
+            }
+            if or(
                 eq(flag, FROM_TOKEN_COMMISSION_DUAL),
                 eq(flag, TO_TOKEN_COMMISSION_DUAL)
-            )
+            ) {
+                referrerNum := 2
+            }
+            if or(
+                eq(flag, FROM_TOKEN_COMMISSION_MULTIPLE),
+                eq(flag, TO_TOKEN_COMMISSION_MULTIPLE)
+            ) {
+                referrerNum := 3 // default referrer num to load real encoded referrer num
+            }
             mstore(
                 commissionInfo,
                 or(
-                    eq(flag, FROM_TOKEN_COMMISSION),
-                    eq(flag, FROM_TOKEN_COMMISSION_DUAL)
+                    or(
+                        eq(flag, FROM_TOKEN_COMMISSION),
+                        eq(flag, FROM_TOKEN_COMMISSION_DUAL)
+                    ),
+                    eq(flag, FROM_TOKEN_COMMISSION_MULTIPLE)
                 )
             ) // isFromTokenCommission
             mstore(
                 add(0x20, commissionInfo),
                 or(
-                    eq(flag, TO_TOKEN_COMMISSION),
-                    eq(flag, TO_TOKEN_COMMISSION_DUAL)
+                    or(
+                        eq(flag, TO_TOKEN_COMMISSION),
+                        eq(flag, TO_TOKEN_COMMISSION_DUAL)
+                    ),
+                    eq(flag, TO_TOKEN_COMMISSION_MULTIPLE)
                 )
             ) // isToTokenCommission
-            mstore(
-                add(0x40, commissionInfo),
-                shr(160, and(commissionData, _COMMISSION_RATE_MASK))
-            ) //commissionRate1
-            mstore(
-                add(0x60, commissionInfo),
-                and(commissionData, _ADDRESS_MASK)
-            ) //referrerAddress1
-            commissionData := calldataload(sub(calldatasize(), 0x40))
-            mstore(
-                add(0xe0, commissionInfo),
-                gt(and(commissionData, _TO_B_COMMISSION_MASK), 0) //isToBCommission
-            )
-            mstore(
-                add(0x80, commissionInfo),
-                and(commissionData, _ADDRESS_MASK) //token
-            )
-            switch eq(isDualreferrers, 1)
+            switch gt(referrerNum, 0)
             case 1 {
-                let commissionData2 := calldataload(sub(calldatasize(), 0x60))
                 mstore(
                     add(0xa0, commissionInfo),
-                    shr(160, and(commissionData2, _COMMISSION_RATE_MASK))
-                ) //commissionRate2
+                    shr(160, and(commissionData, _COMMISSION_RATE_MASK))
+                ) // 1st commissionRate
                 mstore(
                     add(0xc0, commissionInfo),
-                    and(commissionData2, _ADDRESS_MASK)
-                ) //referrerAddress2
+                    and(commissionData, _ADDRESS_MASK)
+                ) // 1st referrerAddress
+                commissionData := calldataload(sub(calldatasize(), 0x40))
+                let toBCommission := NO_TO_B_MODE // default toBCommission is 1 for no-toB commission when commissionData exists
+                if gt(and(commissionData, _TO_B_COMMISSION_MASK), 0) {
+                    toBCommission := TO_B_MODE // toB commission value when commissionData exists
+                }
+                mstore(
+                    add(0x60, commissionInfo),
+                    toBCommission //toBCommission
+                )
+                mstore(
+                    add(0x40, commissionInfo),
+                    and(commissionData, _ADDRESS_MASK) //token
+                )
+                // For multiple commission mode, load the encoded commission length and validate
+                if gt(referrerNum, 2) {
+                    referrerNum := shr(240, and(commissionData, _COMMISSION_LENGTH_MASK))
+                    // require(referrerNum >= MIN_COMMISSION_MULTIPLE_NUM && referrerNum <= MAX_COMMISSION_MULTIPLE_NUM, "invalid referrer num")
+                    if or(lt(referrerNum, MIN_COMMISSION_MULTIPLE_NUM), gt(referrerNum, MAX_COMMISSION_MULTIPLE_NUM)) {
+                        _revertWithReason(
+                            0x00000014696e76616c6964207265666572726572206e756d0000000000000000,
+                            0x58
+                        ) // "invalid referrer num"
+                    }
+                }
+                mstore(add(0x80, commissionInfo), referrerNum) //commissionLength
             }
             default {
-                mstore(add(0xa0, commissionInfo), 0) //commissionRate2
-                mstore(add(0xc0, commissionInfo), 0) //referrerAddress2
-            }            
-            // calculate offset based on commission flag
-            let offset := 0x00
-            if eq(isDualreferrers, 1) {
-                offset := 0x60  // 96 bytes for dual commission
+                let eraseNum := add(mul(MAX_COMMISSION_MULTIPLE_NUM, 2), 3) // 2 * MAX_COMMISSION_MULTIPLE_NUM + 3: token, toBCommission, commissionLength and all commission pairs
+                for { let i := 0 } lt(i, eraseNum) { i := add(i, 1) } {
+                    mstore(add(add(commissionInfo, 0x40), mul(i, 0x20)), 0) // erase commissionInfo.token ~ all commission pairs
+                }
             }
-            if or(
-                eq(flag, FROM_TOKEN_COMMISSION),
-                eq(flag, TO_TOKEN_COMMISSION)
-            ) {
-                offset := 0x40  // 64 bytes for single commission
+            if gt(referrerNum, 1) {
+                for { let i := 1 } lt(i, MAX_COMMISSION_MULTIPLE_NUM) { i := add(i, 1) } {
+                    switch lt(i, referrerNum) // if i < referrerNum, the i-th commission pair is valid
+                    case 1 {
+                        commissionData := calldataload(sub(calldatasize(), add(0x40, mul(i, 0x20))))
+                        let flag2 := and(commissionData, _COMMISSION_FLAG_MASK)
+                        if iszero(eq(flag, flag2)) {
+                            _revertWithReason(
+                                0x00000017696e76616c696420636f6d6d697373696f6e20666c61670000000000,
+                                0x5b
+                            ) // "invalid commission flag"
+                        }
+                        mstore(
+                            add(add(0xa0, commissionInfo), mul(i, 0x40)), // 0xa0: commissionRate0, 0xa0 + 0x40 * i: i-th commissionRate
+                            shr(160, and(commissionData, _COMMISSION_RATE_MASK))
+                        ) //i-th commissionRate
+                        mstore(
+                            add(add(0xc0, commissionInfo), mul(i, 0x40)), // 0xc0: referrerAddress0, 0xc0 + 0x40 * i: i-th referrerAddress
+                            and(commissionData, _ADDRESS_MASK)
+                        ) //i-th referrerAddress
+                    }
+                    default { // if i >= referrerNum, the i-th commission pair is invalid, and erase it
+                        mstore(add(add(0xa0, commissionInfo), mul(i, 0x40)), 0) // erase i-th commissionRate
+                        mstore(add(add(0xc0, commissionInfo), mul(i, 0x40)), 0) // erase i-th referrerAddress
+                    }
+                }
+            }
+            // calculate offset based on referrerNum
+            let offset := 0
+            if gt(referrerNum, 0) {
+                offset := mul(add(referrerNum, 1), 0x20)
             }
             // get first bytes32 of trim data
-            let trimData := calldataload(sub(calldatasize(), add(offset, 32)))
+            let trimData := calldataload(sub(calldatasize(), add(offset, 0x20)))
             flag := and(trimData, _TRIM_FLAG_MASK)
+            let hasTrim := or(
+                eq(flag, TRIM_FLAG),
+                eq(flag, TRIM_DUAL_FLAG)
+            )
             mstore(
                 trimInfo,
-                or(
-                    eq(flag, TRIM_FLAG),
-                    eq(flag, TRIM_DUAL_FLAG)
-                )
+                hasTrim
             ) // hasTrim
-            mstore(
-                add(0x20, trimInfo),
-                shr(160, and(trimData, _TRIM_RATE_MASK))
-            ) // trimRate
-            mstore(
-                add(0x40, trimInfo),
-                and(trimData, _TRIM_EXPECT_AMOUNT_OUT_OR_ADDRESS_MASK)
-            ) // trimAddress
-            // get second bytes32 of trim data
-            trimData := calldataload(sub(calldatasize(), add(offset, 64)))
-            mstore(
-                add(0x60, trimInfo),
-                and(trimData, _TRIM_EXPECT_AMOUNT_OUT_OR_ADDRESS_MASK)
-            ) // expectAmountOut
+            switch eq(hasTrim, 1)
+            case 1{
+                mstore(
+                    add(0x20, trimInfo),
+                    shr(160, and(trimData, _TRIM_RATE_MASK))
+                ) // trimRate
+                mstore(
+                    add(0x40, trimInfo),
+                    and(trimData, _TRIM_EXPECT_AMOUNT_OUT_OR_ADDRESS_MASK)
+                ) // trimAddress
+                // get second bytes32 of trim data
+                trimData := calldataload(sub(calldatasize(), add(offset, 0x40)))
+                let flag2 := and(trimData, _TRIM_FLAG_MASK)
+                if iszero(eq(flag, flag2)) {
+                    _revertWithReason(
+                        0x00000011696e76616c6964207472696d20666c61670000000000000000000000,
+                        0x55
+                    ) // "invalid trim flag"
+                }
+                let toBTrim := NO_TO_B_MODE // default toBTrim is 1 for no-toB trim when trimData exists
+                if gt(and(trimData, _TO_B_TRIM_MASK), 0) {
+                    toBTrim := TO_B_MODE // toB trim value when trimData exists
+                }
+                mstore(
+                    add(0x60, trimInfo),
+                    toBTrim //toBTrim
+                )
+                mstore(
+                    add(0x80, trimInfo),
+                    and(trimData, _TRIM_EXPECT_AMOUNT_OUT_OR_ADDRESS_MASK)
+                ) // expectAmountOut
+            }
+            default {
+                mstore(add(0x20, trimInfo), 0) // trimRate
+                mstore(add(0x40, trimInfo), 0) // trimAddress
+                mstore(add(0x60, trimInfo), 0) // toBTrim
+                mstore(add(0x80, trimInfo), 0) // expectAmountOut
+            }
             switch eq(flag, TRIM_DUAL_FLAG)
             case 1 {
                 // get third bytes32 of trim data
-                trimData := calldataload(sub(calldatasize(), add(offset, 96)))
+                trimData := calldataload(sub(calldatasize(), add(offset, 0x60)))
+                let flag2 := and(trimData, _TRIM_FLAG_MASK)
+                if iszero(eq(flag, flag2)) {
+                    _revertWithReason(
+                        0x00000011696e76616c6964207472696d20666c61670000000000000000000000,
+                        0x55
+                    ) // "invalid trim flag"
+                }
                 mstore(
-                    add(0x80, trimInfo),
+                    add(0xa0, trimInfo),
                     shr(160, and(trimData, _TRIM_RATE_MASK))
                 ) // chargeRate
                 mstore(
-                    add(0xa0, trimInfo),
+                    add(0xc0, trimInfo),
                     and(trimData, _TRIM_EXPECT_AMOUNT_OUT_OR_ADDRESS_MASK)
                 ) // chargeAddress
             }
             default {
-                mstore(add(0x80, trimInfo), 0) // chargeRate
-                mstore(add(0xa0, trimInfo), 0) // chargeAddress
+                mstore(add(0xa0, trimInfo), 0) // chargeRate
+                mstore(add(0xc0, trimInfo), 0) // chargeAddress
             }
         }
 
         if (commissionInfo.isFromTokenCommission || commissionInfo.isToTokenCommission || trimInfo.hasTrim) {
-            emit CommissionAndTrimInfo(commissionInfo.commissionRate, commissionInfo.commissionRate2, commissionInfo.isToBCommission, trimInfo.trimRate, trimInfo.chargeRate);
+            emit CommissionAndTrimInfo(
+                commissionInfo.toBCommission,
+                trimInfo.toBTrim,
+                trimInfo.trimRate,
+                trimInfo.chargeRate
+            );
         }
     }
 
@@ -229,7 +342,7 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                     _revertWithReason(
                         0x000000146765742062616c616e63654f66206661696c65640000000000000000,
                         0x58
-                    )
+                    ) // "get balanceOf failed"
                 }
                 amount := mload(0x00)
             }
@@ -279,13 +392,6 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                 }
                 z := sub(x, y)
             }
-            // a << 8 | b << 4 | c => 0xabc
-            function _getStatus(token, isToB, hasNextRefer) -> d {
-                let a := mul(eq(token, _ETH), 256)
-                let b := mul(isToB, 16)
-                let c := hasNextRefer
-                d := add(a, add(b, c))
-            }
             function _revertWithReason(m, len) {
                 mstore(
                     0,
@@ -299,57 +405,87 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                 revert(0, len)
             }
             function _sendETH(to, amount) {
-                let success := call(gas(), to, amount, 0, 0, 0, 0)
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x0000001c20636f6d6d697373696f6e2077697468206574686572206572726f72, //commission with ether error
-                        0x60
-                    )
+                if and(iszero(eq(to, address())), gt(amount, 0)) {
+                    let success := call(gas(), to, amount, 0, 0, 0, 0)
+                    if eq(success, 0) {
+                        _revertWithReason(
+                            0x0000001b636f6d6d697373696f6e2077697468206574686572206572726f7200,
+                            0x5f
+                        ) // "commission with ether error"
+                    }
                 }
             }
             function _claimToken(token, _payer, to, amount) {
-                let freePtr := mload(0x40)
-                mstore(0x40, add(freePtr, 0x84))
-                mstore(
-                    freePtr,
-                    0x0a5ea46600000000000000000000000000000000000000000000000000000000
-                ) // claimTokens
-                mstore(add(freePtr, 0x04), token)
-                mstore(add(freePtr, 0x24), _payer)
-                mstore(add(freePtr, 0x44), to)
-                mstore(add(freePtr, 0x64), amount)
-                let success := call(
-                    gas(),
-                    _APPROVE_PROXY,
-                    0,
-                    freePtr,
-                    0x84,
-                    0,
-                    0
-                )
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x00000013636c61696d20746f6b656e73206661696c6564000000000000000000,
-                        0x57
+                if gt(amount, 0) {
+                    let freePtr := mload(0x40)
+                    mstore(0x40, add(freePtr, 0x84))
+                    mstore(
+                        freePtr,
+                        0x0a5ea46600000000000000000000000000000000000000000000000000000000
+                    ) // claimTokens
+                    mstore(add(freePtr, 0x04), token)
+                    mstore(add(freePtr, 0x24), _payer)
+                    mstore(add(freePtr, 0x44), to)
+                    mstore(add(freePtr, 0x64), amount)
+                    let success := call(
+                        gas(),
+                        _APPROVE_PROXY,
+                        0,
+                        freePtr,
+                        0x84,
+                        0,
+                        0
                     )
+                    if eq(success, 0) {
+                        _revertWithReason(
+                            0x00000013636c61696d20746f6b656e73206661696c6564000000000000000000,
+                            0x57
+                        ) // "claim tokens failed"
+                    }
                 }
             }
-            // get balance, then scale amount1, amount2 according to balance
-            function _sendTokenWithinBalance(token, to1, rate1, to2, rate2)
-                -> amount1Scaled, amount2Scaled
+            function _sendToken(token, to, amount) {
+                if gt(amount, 0) {
+                    let freePtr := mload(0x40)
+                    mstore(0x40, add(freePtr, 0x44))
+                    mstore(
+                        freePtr,
+                        0xa9059cbb00000000000000000000000000000000000000000000000000000000
+                    ) // transfer
+                    mstore(add(freePtr, 0x04), to)
+                    mstore(add(freePtr, 0x24), amount)
+                    let success := call(
+                        gas(),
+                        token,
+                        0,
+                        freePtr,
+                        0x44,
+                        0,
+                        0x20
+                    )
+                    if eq(success, 0) {
+                        _revertWithReason(
+                            0x0000001b7472616e7366657220746f6b656e2072656665726572206661696c00,
+                            0x5f
+                        ) // "transfer token referer fail"
+                    }
+                }
+            }
+            // get balance, then scale each amount according to balance, and send tokens with scaled amount
+            function _sendTokenWithinBalanceAndEmitEvents(token, totalRate, referrerNum, commissionInfo_)
             {
                 let freePtr := mload(0x40)
-                mstore(0x40, add(freePtr, 0x48))
+                mstore(0x40, add(freePtr, 0x24))
                 mstore(
                     freePtr,
-                    0xa9059cbba9059cbb70a082310000000000000000000000000000000000000000
-                ) // transfer transfer balanceOf
-                // balanceOf
-                mstore(add(freePtr, 0x0c), address())
+                    0x70a0823100000000000000000000000000000000000000000000000000000000
+                ) // balanceOf
+                // get token balance of address(this)
+                mstore(add(freePtr, 0x4), address())
                 let success := staticcall(
                     gas(),
                     token,
-                    add(freePtr, 0x08),
+                    freePtr,
                     0x24,
                     0,
                     0x20
@@ -358,178 +494,100 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                     _revertWithReason(
                         0x000000146765742062616c616e63654f66206661696c65640000000000000000,
                         0x58
-                    )
+                    ) // "get balanceOf failed"
                 }
                 let balanceAfter := mload(0x00)
-                let rateTotal := add(rate1, rate2) // amount = 0.0000001
-                amount1Scaled := _mulDiv(
-                    _mulDiv(rate1, WAD, rateTotal),
-                    balanceAfter,
-                    WAD
-                ) // WARNING: Precision issues may also exist!!
-                if gt(amount1Scaled, balanceAfter) {
-                    _revertWithReason(
-                        0x00000015696e76616c696420616d6f756e74315363616c656400000000000000,
-                        0x59
-                    ) //invalid amount1Scaled
-                }
-                mstore(add(freePtr, 0x08), to1)
-                mstore(add(freePtr, 0x28), amount1Scaled)
-                success := call(
-                    gas(),
-                    token,
-                    0,
-                    add(freePtr, 0x4),
-                    0x44,
-                    0,
-                    0x20
-                )
-                // https://github.com/transmissions11/solmate/blob/e5e0ed64c75e74974151780884e59071d026d84e/src/utils/SafeTransferLib.sol#L54
-                if and(
-                    iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))),
-                    success
-                ) {
-                    success := iszero(
-                        or(iszero(extcodesize(token)), returndatasize())
-                    )
-                }
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x0000001b7472616e7366657220746f6b656e2072656665726572206661696c00,
-                        0x5f
-                    ) //transfer token referrer fail
-                }
-
-                if gt(to2, 0) {
-                    amount2Scaled := _safeSub(balanceAfter, amount1Scaled)
-
-                    mstore(add(freePtr, 0x04), to2)
-                    mstore(add(freePtr, 0x24), amount2Scaled)
-                    success := call(gas(), token, 0, freePtr, 0x44, 0, 0x20)
-                    // https://github.com/transmissions11/solmate/blob/e5e0ed64c75e74974151780884e59071d026d84e/src/utils/SafeTransferLib.sol#L54
-                    if and(
-                        iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))),
-                        success
-                    ) {
-                        success := iszero(
-                            or(iszero(extcodesize(token)), returndatasize())
+                let sendAmount := 0 // the amount of tokens already sent
+                for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                    let rate := mload(add(commissionInfo_, add(0xa0, mul(i, 0x40))))
+                    let amountScaled
+                    switch eq(i, sub(referrerNum, 1))
+                    case 1 { // last referrer
+                        amountScaled := _safeSub(balanceAfter, sendAmount)
+                    }
+                    default { // not last referrer
+                        amountScaled := _mulDiv(
+                            _mulDiv(rate, WAD, totalRate),
+                            balanceAfter,
+                            WAD
                         )
+                        if gt(amountScaled, balanceAfter) {
+                            _revertWithReason(
+                                0x00000014696e76616c696420616d6f756e745363616c65640000000000000000,
+                                0x58
+                            ) // "invalid amountScaled"
+                        }
+                        sendAmount := add(sendAmount, amountScaled)
                     }
-                    if eq(success, 0) {
-                        _revertWithReason(
-                            0x0000001b7472616e7366657220746f6b656e2072656665726572206661696c00,
-                            0x5f
-                        ) //transfer token referrer fail
-                    }
+                    let referrer := mload(add(commissionInfo_, add(0xc0, mul(i, 0x40))))
+                    _sendToken(token, referrer, amountScaled)
+                    _emitCommissionFromToken(token, amountScaled, referrer, rate)
                 }
             }
-            function _emitCommissionFromToken(token, amount, referrer) {
+            function _emitCommissionFromToken(token, amount, referrer, rate) {
                 let freePtr := mload(0x40)
-                mstore(0x40, add(freePtr, 0x60))
+                mstore(0x40, add(freePtr, 0x80))
                 mstore(freePtr, token)
                 mstore(add(freePtr, 0x20), amount)
                 mstore(add(freePtr, 0x40), referrer)
+                mstore(add(freePtr, 0x60), rate)
                 log1(
                     freePtr,
-                    0x60,
-                    0x0d3b1268ca3dbb6d3d8a0ea35f44f8f9d58cf578d732680b71b6904fb2733e0d
-                ) //emit CommissionFromTokenRecord(address,uint256,address)
+                    0x80,
+                    0xcd5eae9d9d0b96532bd1b7dbf6628ce436b2af735829087a03c548439f8bf850
+                ) //emit CommissionFromTokenRecord(address,uint256,address,uint256)
             }
 
-            let token, status
-            {
-                token := mload(add(commissionInfo, 0x80))
-                let isToB := mload(add(commissionInfo, 0xe0))
-                let hasNextRefer := gt(mload(add(commissionInfo, 0xa0)), 0)
-                status := _getStatus(token, isToB, hasNextRefer)
+            let token := mload(add(commissionInfo, 0x40))
+            let toBCommission := mload(add(commissionInfo, 0x60))
+            let totalRate := 0
+            let referrerNum := mload(add(commissionInfo, 0x80))
+            for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                let rate := mload(add(commissionInfo, add(0xa0, mul(i, 0x40))))
+                totalRate := add(totalRate, rate)
             }
-            
-            let referrer1, referrer2, amount1, amount2, rate1, rate2
-            rate1 := mload(add(commissionInfo, 0x40))
-            rate2 := mload(add(commissionInfo, 0xa0))
-            {
-                // let totalRate := add(rate, rate2)
-                if gt(add(rate1, rate2), commissionRateLimit) {
-                    _revertWithReason(
-                        0x0000001b6572726f7220636f6d6d697373696f6e2072617465206c696d697400,
-                        0x5f
-                    ) //"error commission rate limit"
-                }
-                referrer1 := mload(add(commissionInfo, 0x60))
-                amount1 := div(
-                    mul(inputAmount, rate1),
-                    sub(DENOMINATOR, add(rate1, rate2))
-                )
-                referrer2 := mload(add(commissionInfo, 0xc0))
-                amount2 := div(
-                    mul(inputAmount, rate2),
-                    sub(DENOMINATOR, add(rate1, rate2))
-                )
-            }
-
-            switch status
-            case 0x100 {
-                _sendETH(referrer1, amount1)
-                _emitCommissionFromToken(_ETH, amount1, referrer1)
-            }
-            case 0x101 {
-                _sendETH(referrer1, amount1)
-                _emitCommissionFromToken(_ETH, amount1, referrer1)
-                _sendETH(referrer2, amount2)
-                _emitCommissionFromToken(_ETH, amount2, referrer2)
-            }
-            case 0x110 {
-                _sendETH(referrer1, amount1)
-                _emitCommissionFromToken(_ETH, amount1, referrer1)
-            }
-            case 0x111 {
-                _sendETH(referrer1, amount1)
-                _emitCommissionFromToken(_ETH, amount1, referrer1)
-                _sendETH(referrer2, amount2)
-                _emitCommissionFromToken(_ETH, amount2, referrer2)
-            }
-            case 0x000 {
-                _claimToken(token, payer, referrer1, amount1)
-                _emitCommissionFromToken(token, amount1, referrer1)
-            }
-            case 0x001 {
-                _claimToken(token, payer, referrer1, amount1)
-                _emitCommissionFromToken(token, amount1, referrer1)
-                _claimToken(token, payer, referrer2, amount2)
-                _emitCommissionFromToken(token, amount2, referrer2)
-            }
-            case 0x010 {
-                _claimToken(token, payer, address(), amount1)
-                // considering the tax token, we first transfer it into dexrouter, then check balance, after that
-                // scaled amount accordingly
-                let amount1Scaled, amount2Scaled := _sendTokenWithinBalance(
-                    token,
-                    referrer1,
-                    rate1,
-                    0,
-                    0
-                )
-                _emitCommissionFromToken(token, amount1Scaled, referrer1)
-            }
-            case 0x011 {
-                _claimToken(token, payer, address(), add(amount1, amount2))
-                // considering the tax token, we first transfer it into dexrouter, then check balance, after that
-                // scaled amount accordingly
-                let amount1Scaled, amount2Scaled := _sendTokenWithinBalance(
-                    token,
-                    referrer1,
-                    rate1,
-                    referrer2,
-                    rate2
-                )
-                _emitCommissionFromToken(token, amount1Scaled, referrer1)
-                _emitCommissionFromToken(token, amount2Scaled, referrer2)
-            }
-            default {
+            if gt(totalRate, commissionRateLimit) {
                 _revertWithReason(
-                    0x0000000e696e76616c6964207374617475730000000000000000000000000000,
-                    0x52
-                ) // invalid status
+                    0x000000156572726f7220636f6d6d697373696f6e207261746500000000000000,
+                    0x59
+                ) // "error commission rate"
+            }
+            if eq(token, _ETH) { // commission token is ETH, the process is same between no toB mode and toB mode
+                for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                    let rate := mload(add(commissionInfo, add(0xa0, mul(i, 0x40))))
+                    let referrer := mload(add(commissionInfo, add(0xc0, mul(i, 0x40))))
+                    let amount := div(
+                        mul(inputAmount, rate),
+                        sub(DENOMINATOR, totalRate)
+                    )
+                    _sendETH(referrer, amount)
+                    _emitCommissionFromToken(_ETH, amount, referrer, rate)
+                }
+            }
+            if and(iszero(eq(token, _ETH)), eq(toBCommission, NO_TO_B_MODE)) { // commission token is ERC20 with no toB mode
+                for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                    let rate := mload(add(commissionInfo, add(0xa0, mul(i, 0x40))))
+                    let referrer := mload(add(commissionInfo, add(0xc0, mul(i, 0x40))))
+                    let amount := div(
+                        mul(inputAmount, rate),
+                        sub(DENOMINATOR, totalRate)
+                    )
+                    _claimToken(token, payer, referrer, amount)
+                    _emitCommissionFromToken(token, amount, referrer, rate)
+                }
+            }
+            if and(iszero(eq(token, _ETH)), eq(toBCommission, TO_B_MODE)) { // commission token is ERC20 with toB mode
+                let totalAmount := div(
+                    mul(inputAmount, totalRate),
+                    sub(DENOMINATOR, totalRate)
+                )
+                _claimToken(token, payer, address(), totalAmount)
+                _sendTokenWithinBalanceAndEmitEvents(
+                    token,
+                    totalRate,
+                    referrerNum,
+                    commissionInfo
+                )
             }
         }
     }
@@ -545,68 +603,23 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
             return 0;
         }
         uint256 balanceAfter = _getBalanceOf(toToken, address(this));
-        require(balanceAfter >= balanceBefore, "invalid balance after");
-        uint256 inputAmount = balanceAfter - balanceBefore;
-
-        // process commission
-        if (commissionInfo.isToTokenCommission) {
-            require(commissionInfo.commissionRate + commissionInfo.commissionRate2 <= commissionRateLimit, "error commission rate limit");
-            uint256 commissionAmount = inputAmount * (commissionInfo.commissionRate + commissionInfo.commissionRate2) / DENOMINATOR;
-            _doCommissionOrTrimToTokenInternal(
-                true,
-                toToken,
-                commissionAmount,
-                commissionInfo.commissionRate,
-                commissionInfo.refererAddress,
-                commissionInfo.commissionRate2,
-                commissionInfo.refererAddress2
-            );
-            totalAmount = commissionAmount;
-            inputAmount -= commissionAmount;
-        }
-
-        // process trim
-        if (trimInfo.hasTrim && inputAmount > trimInfo.expectAmountOut) {
-            require(trimInfo.trimRate <= TRIM_RATE_LIMIT, "error trim rate limit");
-            require(trimInfo.chargeRate <= TRIM_DENOMINATOR, "error charge rate");
-            uint256 trimAmount = inputAmount - trimInfo.expectAmountOut;
-            uint256 allowedMaxTrimAmount = inputAmount * trimInfo.trimRate / TRIM_DENOMINATOR;
-            if (trimAmount > allowedMaxTrimAmount) {
-                trimAmount = allowedMaxTrimAmount;
-            }
-            _doCommissionOrTrimToTokenInternal(
-                false,
-                toToken,
-                trimAmount,
-                (TRIM_DENOMINATOR - trimInfo.chargeRate),
-                trimInfo.trimAddress,
-                trimInfo.chargeRate,
-                trimInfo.chargeAddress
-            );
-            totalAmount += trimAmount;
-            inputAmount -= trimAmount;
-        }
-
-        // transfer toToken to receiver
-        _sendETHOrToken(toToken, receiver, inputAmount);
-    }
-
-    // Process commission or trim to token
-    function _doCommissionOrTrimToTokenInternal(
-        bool isCommission,
-        address toToken,
-        uint256 totalAmount,
-        uint256 rate1,
-        address address1,
-        uint256 rate2,
-        address address2
-    ) private {
         assembly ("memory-safe") {
-            // a << 4 | b => 0xab
-            function _getStatus(flag, token) -> c {
-                let a := mul(gt(flag, 0), 16)
-                let b := eq(token, _ETH)
-                c := add(a, b)
+            // https://github.com/Vectorized/solady/blob/701406e8126cfed931645727b274df303fbcd94d/src/utils/FixedPointMathLib.sol#L595
+            function _mulDiv(x, y, d) -> z {
+                z := mul(x, y)
+                // Equivalent to `require(d != 0 && (y == 0 || x <= type(uint256).max / y))`.
+                if iszero(mul(or(iszero(x), eq(div(z, x), y)), d)) {
+                    mstore(0x00, 0xad251c27) // `MulDivFailed()`.
+                    revert(0x1c, 0x04)
+                }
+                z := div(z, d)
+            }
+            function _safeSub(x, y) -> z {
+                if lt(x, y) {
+                    mstore(0x00, 0x46e72d03) // `SafeSubFailed()`.
+                    revert(0x1c, 0x04)
+                }
+                z := sub(x, y)
             }
             function _revertWithReason(m, len) {
                 mstore(
@@ -621,58 +634,55 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                 revert(0, len)
             }
             function _sendETH(to, amount) {
-                let success := call(gas(), to, amount, 0, 0, 0, 0)
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x0000001173656e64206574686572206661696c65640000000000000000000000,
-                        0x55
-                    ) // "send ether failed"
+                if and(iszero(eq(to, address())), gt(amount, 0)) {
+                    let success := call(gas(), to, amount, 0, 0, 0, 0)
+                    if eq(success, 0) {
+                        _revertWithReason(
+                            0x0000001173656e64206574686572206661696c65640000000000000000000000,
+                            0x55
+                        ) // "send ether failed"
+                    }
                 }
             }
             function _sendToken(token, to, amount) {
-                let freePtr := mload(0x40)
-                mstore(0x40, add(freePtr, 0x44))
-                mstore(
-                    freePtr,
-                    0xa9059cbb00000000000000000000000000000000000000000000000000000000
-                ) // transfer
-                mstore(add(freePtr, 0x04), to)
-                mstore(add(freePtr, 0x24), amount)
-                let success := call(
-                    gas(),
-                    token,
-                    0,
-                    freePtr,
-                    0x44,
-                    0,
-                    0x20
-                )
-                if and(
-                    iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))),
-                    success
-                ) {
-                    success := iszero(
-                        or(iszero(extcodesize(token)), returndatasize())
+                if gt(amount, 0) {
+                    let freePtr := mload(0x40)
+                    mstore(0x40, add(freePtr, 0x44))
+                    mstore(
+                        freePtr,
+                        0xa9059cbb00000000000000000000000000000000000000000000000000000000
+                    ) // transfer
+                    mstore(add(freePtr, 0x04), to)
+                    mstore(add(freePtr, 0x24), amount)
+                    let success := call(
+                        gas(),
+                        token,
+                        0,
+                        freePtr,
+                        0x44,
+                        0,
+                        0x20
                     )
-                }
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x000000157472616e7366657220746f6b656e206661696c656400000000000000,
-                        0x59
-                    ) // "transfer token failed"
+                    if eq(success, 0) {
+                        _revertWithReason(
+                            0x000000157472616e7366657220746f6b656e206661696c656400000000000000,
+                            0x59
+                        ) // "transfer token failed"
+                    }
                 }
             }
-            function _emitCommissionToToken(token, amount, referrer) {
+            function _emitCommissionToToken(token, amount, referrer, rate) {
                 let freePtr := mload(0x40)
-                mstore(0x40, add(freePtr, 0x60))
+                mstore(0x40, add(freePtr, 0x80))
                 mstore(freePtr, token)
                 mstore(add(freePtr, 0x20), amount)
                 mstore(add(freePtr, 0x40), referrer)
+                mstore(add(freePtr, 0x60), rate)
                 log1(
                     freePtr,
-                    0x60,
-                    0xf171268de859ec269c52bbfac94dcb7715e784de194342abb284bf34fd30b32d
-                ) //emit CommissionToTokenRecord(address,uint256,address)
+                    0x80,
+                    0x3cfb523a4c38d88561dd3bf04805a31715c8b5fc468a03b8d684356f360dea99
+                ) //emit CommissionToTokenRecord(address,uint256,address,uint256)
             }
             function _emitPositiveSlippageTrimRecord(token, trimAmount, trimAddress) {
                 let freePtr := mload(0x40)
@@ -698,68 +708,138 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                     0xfd08115c8e43d2a49d95ee18d7f69b8bbac60bd368c73cf22d30664a22a0626d
                 ) // emit PositiveSlippageChargeRecord(address,uint256,address)
             }
+            function _processCommission(commissionInfo_, toToken_, inputAmount) -> commissionAmount {
+                let referrerNum := mload(add(commissionInfo_, 0x80)) // commissionInfo.referrerNum
+                let totalRate := 0
+                for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                    let rate := mload(add(commissionInfo_, add(0xa0, mul(i, 0x40))))
+                    totalRate := add(totalRate, rate)
+                }
+                if gt(totalRate, commissionRateLimit) {
+                    _revertWithReason(
+                        0x000000156572726f7220636f6d6d697373696f6e207261746500000000000000,
+                        0x59
+                    ) // "error commission rate"
+                }
+                commissionAmount := 0
+                switch eq(toToken_, _ETH)
+                case 1 { // commission token is ETH
+                    for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                        let rate := mload(add(commissionInfo_, add(0xa0, mul(i, 0x40))))
+                        let amount := _mulDiv(inputAmount, rate, DENOMINATOR)
+                        let referrer := mload(add(commissionInfo_, add(0xc0, mul(i, 0x40))))
+                        _sendETH(referrer, amount)
+                        _emitCommissionToToken(_ETH, amount, referrer, rate)
+                        commissionAmount := add(commissionAmount, amount)
+                    }
+                }
+                default { // commission token is ERC20
+                    for { let i := 0 } lt(i, referrerNum) { i := add(i, 1) } {
+                        let rate := mload(add(commissionInfo_, add(0xa0, mul(i, 0x40))))
+                        let amount := _mulDiv(inputAmount, rate, DENOMINATOR)
+                        let referrer := mload(add(commissionInfo_, add(0xc0, mul(i, 0x40))))
+                        _sendToken(toToken_, referrer, amount)
+                        _emitCommissionToToken(toToken_, amount, referrer, rate)
+                        commissionAmount := add(commissionAmount, amount)
+                    }
+                }
+            } 
+            function _processTrim(trimInfo_, toToken_, inputAmount) -> trimAmount {
+                let trimRate := mload(add(trimInfo_, 0x20)) // trimInfo.trimRate
+                let chargeRate := mload(add(trimInfo_, 0xa0)) // trimInfo.chargeRate
+                // require(trimInfo.trimRate <= TRIM_RATE_LIMIT, "error trim rate");
+                if gt(trimRate, TRIM_RATE_LIMIT) {
+                    _revertWithReason(
+                        0x0000000f6572726f72207472696d207261746500000000000000000000000000,
+                        0x53
+                    ) // "error trim rate"
+                }
+                // require(trimInfo.chargeRate <= TRIM_DENOMINATOR, "error charge rate");
+                if gt(chargeRate, TRIM_DENOMINATOR) {
+                    _revertWithReason(
+                        0x000000116572726f722063686172676520726174650000000000000000000000,
+                        0x55
+                    ) // "error charge rate"
+                }
+                // uint256 trimAmount = inputAmount - trimInfo.expectAmountOut;
+                let expectAmountOut := mload(add(trimInfo_, 0x80)) // trimInfo.expectAmountOut
+                trimAmount := sub(inputAmount, expectAmountOut)
+                // uint256 allowedMaxTrimAmount = inputAmount * trimInfo.trimRate / TRIM_DENOMINATOR;
+                let allowedMaxTrimAmount := _mulDiv(inputAmount, trimRate, TRIM_DENOMINATOR)
+                // trimAmount = min(trimAmount, allowedMaxTrimAmount)
+                if gt(trimAmount, allowedMaxTrimAmount) {
+                    trimAmount := allowedMaxTrimAmount
+                }
 
-            let amount1 := div(mul(totalAmount, rate1), add(rate1, rate2))
-            let amount2 := sub(totalAmount, amount1)
-            address1 := shr(96, shl(96, address1))
-            address2 := shr(96, shl(96, address2))
+                // send token and emit events
+                // actualChargeAmount = trimAmount * chargeRate / TRIM_DENOMINATOR
+                let actualChargeAmount := _mulDiv(trimAmount, chargeRate, TRIM_DENOMINATOR)
+                // actualTrimAmount = trimAmount - actualChargeAmount
+                let actualTrimAmount := sub(trimAmount, actualChargeAmount)
+                switch eq(toToken_, _ETH)
+                case 1 { // commission token is ETH
+                    let trimAddress := mload(add(trimInfo_, 0x40)) // trimInfo.trimAddress
+                    _sendETH(trimAddress, actualTrimAmount)
+                    _emitPositiveSlippageTrimRecord(_ETH, actualTrimAmount, trimAddress)
 
-            let status := _getStatus(isCommission, toToken)
-            switch status
-            case 0x11 { // commission with ETH
-                if gt(rate1, 0) {
-                    _sendETH(address1, amount1)
-                    _emitCommissionToToken(_ETH, amount1, address1)
+                    let chargeAddress := mload(add(trimInfo_, 0xc0)) // trimInfo.chargeAddress
+                    _sendETH(chargeAddress, actualChargeAmount)
+                    _emitPositiveSlippageChargeRecord(_ETH, actualChargeAmount, chargeAddress)
                 }
-                if gt(rate2, 0) {
-                    _sendETH(address2, amount2)
-                    _emitCommissionToToken(_ETH, amount2, address2)
-                }
-            }
-            case 0x10 { // commission with token
-                if gt(rate1, 0) {
-                    _sendToken(toToken, address1, amount1)
-                    _emitCommissionToToken(toToken, amount1, address1)
-                }
-                if gt(rate2, 0) {
-                    _sendToken(toToken, address2, amount2)
-                    _emitCommissionToToken(toToken, amount2, address2)
+                case 0 { // commission token is ERC20
+                    let trimAddress := mload(add(trimInfo_, 0x40)) // trimInfo.trimAddress
+                    _sendToken(toToken_, trimAddress, actualTrimAmount)
+                    _emitPositiveSlippageTrimRecord(toToken_, actualTrimAmount, trimAddress)
+
+                    let chargeAddress := mload(add(trimInfo_, 0xc0)) // trimInfo.chargeAddress
+                    _sendToken(toToken_, chargeAddress, actualChargeAmount)
+                    _emitPositiveSlippageChargeRecord(toToken_, actualChargeAmount, chargeAddress)
                 }
             }
-            case 0x01 { // trim with ETH
-                if gt(rate1, 0) {
-                    _sendETH(address1, amount1)
-                    _emitPositiveSlippageTrimRecord(_ETH, amount1, address1)
-                }
-                if gt(rate2, 0) {
-                    _sendETH(address2, amount2)
-                    _emitPositiveSlippageChargeRecord(_ETH, amount2, address2)
-                }
+
+            // require(balanceAfter > balanceBefore, "invalid balance after");
+            if or(gt(balanceBefore, balanceAfter), eq(balanceAfter, balanceBefore)) {
+                _revertWithReason(
+                    0x00000015696e76616c69642062616c616e636520616674657200000000000000,
+                    0x59
+                ) // "invalid balance after"
             }
-            case 0x00 { // trim with token
-                if gt(rate1, 0) {
-                    _sendToken(toToken, address1, amount1)
-                    _emitPositiveSlippageTrimRecord(toToken, amount1, address1)
-                }
-                if gt(rate2, 0) {
-                    _sendToken(toToken, address2, amount2)
-                    _emitPositiveSlippageChargeRecord(toToken, amount2, address2)
-                }
+            let inputAmount := sub(balanceAfter, balanceBefore)
+
+            // process commission
+            let flag := mload(add(commissionInfo, 0x20)) // commissionInfo.isToTokenCommission
+            if gt(flag, 0) { // commissionInfo.isToTokenCommission == True
+                let commissionAmount := _processCommission(commissionInfo, toToken, inputAmount)
+                inputAmount := sub(inputAmount, commissionAmount)
+                totalAmount := commissionAmount
+            }
+
+            // process trim
+            flag := mload(add(trimInfo, 0x00)) // trimInfo.hasTrim
+            let expectAmountOut := mload(add(trimInfo, 0x80)) // trimInfo.expectAmountOut
+            if and(gt(flag, 0), gt(inputAmount, expectAmountOut)) { // trimInfo.hasTrim == True && inputAmount > trimInfo.expectAmountOut
+                let trimAmount := _processTrim(trimInfo, toToken, inputAmount)
+                inputAmount := sub(inputAmount, trimAmount)
+                totalAmount := add(totalAmount, trimAmount)
+            }
+
+            // transfer toToken to receiver
+            switch eq(toToken, _ETH)
+            case 1 {
+                _sendETH(shr(96, shl(96, receiver)), inputAmount)
             }
             default {
-                _revertWithReason(
-                    0x0000000e696e76616c6964207374617475730000000000000000000000000000,
-                    0x52
-                ) // invalid status
+                _sendToken(toToken, shr(96, shl(96, receiver)), inputAmount)
             }
         }
     }
 
-    function _sendETHOrToken(
-        address token,
-        address to,
-        uint256 amount
-    ) private {
+    function _validateCommissionInfo(
+        CommissionInfo memory commissionInfo,
+        address fromToken,
+        address toToken,
+        uint256 mode
+    ) internal pure override {
         assembly ("memory-safe") {
             function _revertWithReason(m, len) {
                 mstore(
@@ -773,84 +853,67 @@ abstract contract CommissionLib is AbstractCommissionLib, CommonUtils {
                 mstore(0x40, m)
                 revert(0, len)
             }
-            function _sendETH(_to, _amount) {
-                let success := call(gas(), _to, _amount, 0, 0, 0, 0)
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x0000001173656e64206574686572206661696c65640000000000000000000000,
-                        0x55
-                    ) // "send ether failed"
-                }
-            }
-            function _sendToken(_token, _to, _amount) {
-                let freePtr := mload(0x40)
-                mstore(0x40, add(freePtr, 0x44))
-                mstore(
-                    freePtr,
-                    0xa9059cbb00000000000000000000000000000000000000000000000000000000
-                ) // transfer
-                mstore(add(freePtr, 0x04), _to)
-                mstore(add(freePtr, 0x24), _amount)
-                let success := call(
-                    gas(),
-                    _token,
-                    0,
-                    freePtr,
-                    0x44,
-                    0,
-                    0x20
-                )
-                if and(
-                    iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))),
-                    success
-                ) {
-                    success := iszero(
-                        or(iszero(extcodesize(_token)), returndatasize())
-                    )
-                }
-                if eq(success, 0) {
-                    _revertWithReason(
-                        0x000000157472616e7366657220746f6b656e206661696c656400000000000000,
-                        0x59
-                    ) // "transfer token failed"
-                }
-            }
-            switch eq(token, _ETH)
-            case 1 {
-                _sendETH(shr(96, shl(96, to)), amount)
-            }
-            default {
-                _sendToken(token, shr(96, shl(96, to)), amount)
-            }
-        }
-    }
 
-    function _validateCommissionInfo(
-        CommissionInfo memory commissionInfo,
-        address fromToken,
-        address toToken,
-        uint256 mode
-    ) internal pure override {
-        if ((
-            (mode & _MODE_NO_TRANSFER) != 0 
-         || (mode & _MODE_BY_INVEST) != 0
-         || (mode & _MODE_PERMIT2) != 0
-        )
-         && commissionInfo.isFromTokenCommission) {
-            revert("From token commission not supported");
+            // if ((
+            //     (mode & _MODE_NO_TRANSFER) != 0 
+            // || (mode & _MODE_BY_INVEST) != 0
+            // || (mode & _MODE_PERMIT2) != 0
+            // )
+            // && commissionInfo.isFromTokenCommission) {
+            //     revert("From commission not support");
+            // }
+            let flag := or(
+                or(
+                    gt(and(mode, _MODE_NO_TRANSFER), 0),
+                    gt(and(mode, _MODE_BY_INVEST), 0)
+                ),
+                gt(and(mode, _MODE_PERMIT2), 0)
+            )
+            let isFromTokenCommission := mload(add(commissionInfo, 0x00)) // commissionInfo.isFromTokenCommission
+            if and(flag, isFromTokenCommission) {
+                _revertWithReason(
+                    0x0000001b46726f6d20636f6d6d697373696f6e206e6f7420737570706f727400,
+                    0x5f
+                ) // "From commission not support"
+            }
+
+            // if(fromToken == toToken) {
+            //     revert("Invalid tokens");
+            // }
+            if eq(fromToken, toToken) {
+                _revertWithReason(
+                    0x0000000e496e76616c696420746f6b656e730000000000000000000000000000,
+                    0x52
+                ) // "Invalid tokens"
+            }
+
+            // if (commissionInfo.isFromTokenCommission && commissionInfo.isToTokenCommission) {
+            //     revert("Invalid commission direction");
+            // }
+            let isToTokenCommission := mload(add(commissionInfo, 0x20)) // commissionInfo.isToTokenCommission
+            if and(isToTokenCommission, isFromTokenCommission) {
+                _revertWithReason(
+                    0x0000001c496e76616c696420636f6d6d697373696f6e20646972656374696f6e,
+                    0x60
+                ) // "Invalid commission direction"
+            }
+
+            // require(
+            //     (commissionInfo.isFromTokenCommission && commissionInfo.token == fromToken)
+            //         || (commissionInfo.isToTokenCommission && commissionInfo.token == toToken)
+            //         || (!commissionInfo.isFromTokenCommission && !commissionInfo.isToTokenCommission),
+            //     "Invalid commission info"
+            // );
+            let token := mload(add(commissionInfo, 0x40)) // commissionInfo.token
+            flag := and(isFromTokenCommission, eq(token, fromToken))
+            flag := or(flag, and(isToTokenCommission, eq(token, toToken)))
+            flag := or(flag, and(iszero(isFromTokenCommission), iszero(isToTokenCommission)))
+            if iszero(flag) {
+                _revertWithReason(
+                    0x00000017496e76616c696420636f6d6d697373696f6e20696e666f0000000000,
+                    0x5b
+                ) // "Invalid commission info"
+            }
         }
-        if(fromToken == toToken) {
-            revert("Invalid tokens");
-        }
-        if (commissionInfo.isFromTokenCommission && commissionInfo.isToTokenCommission) {
-            revert("Invalid commission direction");
-        }
-        
-        require(
-            (commissionInfo.isFromTokenCommission && commissionInfo.token == fromToken)
-                || (commissionInfo.isToTokenCommission && commissionInfo.token == toToken)
-                || (!commissionInfo.isFromTokenCommission && !commissionInfo.isToTokenCommission),
-            "Invalid commission info"
-        );
     }
 }

--- a/test/dexRouter/common/CommissionHelper.t.sol
+++ b/test/dexRouter/common/CommissionHelper.t.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {console2} from "forge-std/console2.sol";
+
+contract CommissionHelper {
+    uint256 internal constant FROM_TOKEN_COMMISSION =
+        0x3ca20afc2aaa0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant TO_TOKEN_COMMISSION =
+        0x3ca20afc2bbb0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant FROM_TOKEN_COMMISSION_DUAL =
+        0x22220afc2aaa0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant TO_TOKEN_COMMISSION_DUAL =
+        0x22220afc2bbb0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant FROM_TOKEN_COMMISSION_MULTIPLE =
+        0x88880afc2aaa0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant TO_TOKEN_COMMISSION_MULTIPLE =
+        0x88880afc2bbb0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant _COMMISSION_RATE_MASK =
+        0x000000000000ffffffffffff0000000000000000000000000000000000000000;
+    uint256 internal constant _COMMISSION_FLAG_MASK =
+        0xffffffffffff0000000000000000000000000000000000000000000000000000;
+    uint256 internal constant _COMMISSION_LENGTH_MASK =
+        0x00ff000000000000000000000000000000000000000000000000000000000000;
+    uint256 internal constant _TO_B_COMMISSION_MASK =
+        0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 internal constant _ADDRESS_MASK =
+        0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff;
+
+    uint256 internal constant MIN_COMMISSION_MULTIPLE_NUM = 3; // min referrer num for multiple commission
+    uint256 internal constant MAX_COMMISSION_MULTIPLE_NUM = 8; // max referrer num for multiple commission
+
+    /*
+     * Single commission:
+     * ┌──────────────────────────────────────────┬──────────────────────────────────────────┐
+     * │            2nd bytes32                   │              1st bytes32                 │
+     * │      (isToB + padding + token_addr)      │      (flag + rate + referer_addr)        │
+     * ├────────┬──────────────────┬──────────────┼─────────────┬─────────────┬──────────────┤
+     * │ isToB  │     padding      │token_address │    flag     │    rate     │referer_addr  │
+     * │ 1 byte │    11 bytes      │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │
+     * ├────────┼──────────────────┼──────────────┼─────────────┼─────────────┼──────────────┤
+     * │ 0x80or │0x0000000000000000000000│ token  │0x3ca20afc   │    rate1    │  referrer1   │
+     * │ 0x00   │                  │              │2aaa/2bbb    │             │              │
+     * └────────┴──────────────────┴──────────────┴─────────────┴─────────────┴──────────────┘
+     * Dual commission:
+     * ┌──────────────────────────────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┐
+     * │            3rd bytes32                   │            2nd bytes32                   │             1st bytes32                  │
+     * │      (flag + rate2 + referer_addr2)      │      (isToB + padding + token_addr)      │      (flag + rate1 + referer_addr1)      │
+     * ├─────────────┬─────────────┬──────────────┼────────┬──────────────────┬──────────────┼─────────────┬─────────────┬──────────────┤
+     * │    flag     │   rate2     │referer_addr2 │ isToB  │     padding      │token_address │    flag     │   rate1     │referer_addr1 │
+     * │   6 bytes   │   6 bytes   │   20 bytes   │ 1 byte │    11 bytes      │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │
+     * ├─────────────┼─────────────┼──────────────┼────────┼──────────────────┼──────────────┼─────────────┼─────────────┼──────────────┤
+     * │0x22220afc   │   rate2     │   referer2   │ 0x80or │0x0000000000000000000000│ token  │0x22220afc   │   rate1     │   referer1   │
+     * │2aaa/2bbb    │             │              │ 0x00   │                  │              │2aaa/2bbb    │             │              │
+     * └─────────────┴─────────────┴──────────────┴────────┴──────────────────┴──────────────┴─────────────┴─────────────┴──────────────┘
+     * Multiple commission:
+     * ┌────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┐
+     * │            │            4th bytes32                   │            3rd bytes32                   │            2nd bytes32                   │             1st bytes32                  │
+     * │            │      (flag + rate3 + referer_addr3)      │      (flag + rate2 + referer_addr2)      │      (isToB + padding + token_addr)      │      (flag + rate1 + referer_addr1)      │
+     * │ Maybe      ├─────────────┬─────────────┬──────────────┼─────────────┬─────────────┬──────────────┼────────┬───────┬──────────┬──────────────┼─────────────┬─────────────┬──────────────┤
+     * │ more       │    flag     │   rate3     │referer_addr3 │    flag     │   rate2     │referer_addr2 │ isToB  │padding|referrer_num│token_address│    flag    │   rate1     │referer_addr1 │
+     * │ commission │   6 bytes   │   6 bytes   │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │ 1 byte │10bytes|  1 byte  │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │
+     * │            ├─────────────┼─────────────┼──────────────┼─────────────┼─────────────┼──────────────┼────────┼───────┼──────────┼──────────────┼─────────────┼─────────────┼──────────────┤
+     * │            │0x88880afc   │   rate3     │   referer3   │0x88880afc   │   rate2     │   referer2   │ 0x80or |10 empty| num >=3 |    token     │0x88880afc   │   rate1     │   referer1   │
+     * │            │2aaa/2bbb    │             │              │2aaa/2bbb    │             │              │ 0x00   │ bytes |&& num <=8│              │2aaa/2bbb    │             │              │
+     * └────────────┴─────────────┴─────────────┴──────────────┴─────────────┴─────────────┴──────────────┴────────┴──────────────────┴──────────────┴─────────────┴─────────────┴──────────────┘
+    */
+
+    // Parse commission info from encoded bytes
+    // Returns a struct containing all parsed commission parameters
+    struct CommissionInfo {
+        bool isFromTokenCommission; //0x00
+        bool isToTokenCommission; //0x20
+        address token; // 0x40
+        bool isToBCommission; // 0x60
+        uint256 commissionLength; // 0x80
+        uint256 commissionRate; // 0xa0
+        address referrerAddress; // 0xc0
+        uint256 commissionRate2; // 0xe0
+        address referrerAddress2; // 0x100
+        uint256 commissionRate3; // 0x120
+        address referrerAddress3; // 0x140
+        uint256 commissionRate4; // 0x160
+        address referrerAddress4; // 0x180
+        uint256 commissionRate5; // 0x1a0
+        address referrerAddress5; // 0x1c0
+        uint256 commissionRate6; // 0x1e0
+        address referrerAddress6; // 0x200
+        uint256 commissionRate7; // 0x220
+        address referrerAddress7; // 0x240
+        uint256 commissionRate8; // 0x260
+        address referrerAddress8; // 0x280
+    }
+
+    // Unified commission info builder for commission
+    // isFromTokenCommission and isToTokenCommission cannot both be true or both be false
+    // Elements at the same index in commissionRates and referrerAddresses must both have values or both be 0
+    function _buildCommissionInfoUnified(
+        bool isFromTokenCommission,
+        bool isToTokenCommission,
+        address token,
+        bool isToBCommission,
+        uint256[] memory commissionRates,
+        address[] memory referrerAddresses
+    ) internal pure returns (bytes memory) {
+        // Verify that isFromTokenCommission and isToTokenCommission cannot both be true or both be false
+        require(
+            isFromTokenCommission != isToTokenCommission,
+            "Exactly one of isFromTokenCommission or isToTokenCommission must be true"
+        );
+        // Verify that elements at the same index in commissionRates and referrerAddresses must both have values or both be 0, and validate length
+        uint256 commissionLength = commissionRates.length;
+        require(commissionLength == referrerAddresses.length, "commissionRates and referrerAddresses must have the same length");
+        require(commissionLength >= 1 && commissionLength <= MAX_COMMISSION_MULTIPLE_NUM, "invalid commission length");
+        for (uint256 i = 0; i < commissionLength; i++) {
+            require(commissionRates[i] == 0 && referrerAddresses[i] == address(0) || commissionRates[i] > 0 && referrerAddresses[i] != address(0), "commissionRates and referrerAddresses value must be set or unset at the same index");
+        }
+        bytes memory commissionInfo;
+        uint256 toBCommissionFlag = isToBCommission ? (1 << 255) : 0;
+        uint256 flagValue;
+        uint256 lengthValue = 0;
+        if (commissionLength == 1) {
+            if (isFromTokenCommission) {
+                flagValue = FROM_TOKEN_COMMISSION;
+            } else {
+                flagValue = TO_TOKEN_COMMISSION;
+            }
+        } else if (commissionLength == 2) {
+            if (isFromTokenCommission) {
+                flagValue = FROM_TOKEN_COMMISSION_DUAL;
+            } else {
+                flagValue = TO_TOKEN_COMMISSION_DUAL;
+            }
+        } else {
+            if (isFromTokenCommission) {
+                flagValue = FROM_TOKEN_COMMISSION_MULTIPLE;
+            } else {
+                flagValue = TO_TOKEN_COMMISSION_MULTIPLE;
+            }
+            lengthValue = commissionLength << 240; // length is only encoded when commissionLength > 2
+        }
+
+        // At least one referrer address, assemble the first 2 bytes32
+        commissionInfo = abi.encodePacked(
+            bytes32(toBCommissionFlag | lengthValue | uint256(uint160(token))),
+            bytes32(
+                (flagValue & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                ((uint256(commissionRates[0]) << 160) & 0x000000000000ffffffffffff0000000000000000000000000000000000000000) |
+                (uint256(uint160(referrerAddresses[0])) & 0x00000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+            )
+        );
+        // Assemble the remaining bytes32
+        for (uint256 i = 1; i < commissionLength; i++) {
+            commissionInfo = abi.encodePacked(
+                bytes32(
+                    (flagValue & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                    ((uint256(commissionRates[i]) << 160) & 0x000000000000ffffffffffff0000000000000000000000000000000000000000) |
+                    (uint256(uint160(referrerAddresses[i])) & 0x00000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+                ),
+                commissionInfo
+            );
+        }
+        return commissionInfo;
+    }
+
+    function _parseCommissionInfo(bytes memory encodedCommissionInfo) internal view returns (CommissionInfo memory commissionInfo) {
+        uint256 bytesLength = encodedCommissionInfo.length;
+        require(bytesLength >= 64, "Invalid commission info length");
+        
+        CommissionInfo memory info;
+
+        // Same parse logic as _getCommissionAndTrimInfo in CommissionLib.sol except the commissionData loading logic
+        assembly ("memory-safe") {
+            function _revertWithReason(m, len) {
+                mstore(
+                    0,
+                    0x08c379a000000000000000000000000000000000000000000000000000000000
+                )
+                mstore(
+                    0x20,
+                    0x0000002000000000000000000000000000000000000000000000000000000000
+                )
+                mstore(0x40, m)
+                revert(0, len)
+            }
+
+            let commissionData := mload(add(encodedCommissionInfo, bytesLength)) // directly load the last bytes32 of encodedCommissionInfo
+            let flag := and(commissionData, _COMMISSION_FLAG_MASK)
+            let referrerNum := 0
+            if or(
+                eq(flag, FROM_TOKEN_COMMISSION),
+                eq(flag, TO_TOKEN_COMMISSION)
+            ) {
+                referrerNum := 1
+            }
+            if or(
+                eq(flag, FROM_TOKEN_COMMISSION_DUAL),
+                eq(flag, TO_TOKEN_COMMISSION_DUAL)
+            ) {
+                referrerNum := 2
+            }
+            if or(
+                eq(flag, FROM_TOKEN_COMMISSION_MULTIPLE),
+                eq(flag, TO_TOKEN_COMMISSION_MULTIPLE)
+            ) {
+                referrerNum := 3 // default referrer num to load real encoded referrer num
+            }
+            mstore(
+                commissionInfo,
+                or(
+                    eq(flag, FROM_TOKEN_COMMISSION),
+                    eq(flag, FROM_TOKEN_COMMISSION_DUAL)
+                )
+            ) // isFromTokenCommission
+            mstore(
+                add(0x20, commissionInfo),
+                or(
+                    eq(flag, TO_TOKEN_COMMISSION),
+                    eq(flag, TO_TOKEN_COMMISSION_DUAL)
+                )
+            ) // isToTokenCommission
+            switch gt(referrerNum, 0)
+            case 1 {
+                mstore(
+                    add(0xa0, commissionInfo),
+                    shr(160, and(commissionData, _COMMISSION_RATE_MASK))
+                ) // 1st commissionRate
+                mstore(
+                    add(0xc0, commissionInfo),
+                    and(commissionData, _ADDRESS_MASK)
+                ) // 1st referrerAddress
+                commissionData := mload(sub(add(encodedCommissionInfo, bytesLength), 0x20)) // load the second last bytes32 of encodedCommissionInfo
+                mstore(
+                    add(0x60, commissionInfo),
+                    gt(and(commissionData, _TO_B_COMMISSION_MASK), 0) //isToBCommission
+                )
+                mstore(
+                    add(0x40, commissionInfo),
+                    and(commissionData, _ADDRESS_MASK) //token
+                )
+                // For multiple commission mode, load the encoded commission length and validate
+                if gt(referrerNum, 2) {
+                    referrerNum := shr(240, and(commissionData, _COMMISSION_LENGTH_MASK))
+                    // require(referrerNum >= MIN_COMMISSION_MULTIPLE_NUM && referrerNum <= MAX_COMMISSION_MULTIPLE_NUM, "invalid referrer num")
+                    if or(lt(referrerNum, MIN_COMMISSION_MULTIPLE_NUM), gt(referrerNum, MAX_COMMISSION_MULTIPLE_NUM)) {
+                        _revertWithReason(
+                            0x00000014696e76616c6964207265666572726572206e756d0000000000000000,
+                            0x58
+                        ) // "invalid referrer num"
+                    }
+                }
+                mstore(add(0x80, commissionInfo), referrerNum) //commissionLength
+            }
+            default {
+                let eraseNum := add(mul(MAX_COMMISSION_MULTIPLE_NUM, 2), 3) // 2 * MAX_COMMISSION_MULTIPLE_NUM + 3: token, isToBCommission, commissionLength and all commission pairs
+                for { let i := 0 } lt(i, eraseNum) { i := add(i, 1) } {
+                    mstore(add(add(commissionInfo, 0x40), mul(i, 0x20)), 0) // erase commissionInfo.token ~ all commission pairs
+                }
+            }
+            if gt(referrerNum, 1) {
+                for { let i := 1 } lt(i, MAX_COMMISSION_MULTIPLE_NUM) { i := add(i, 1) } {
+                    switch lt(i, referrerNum) // if i < referrerNum, the i-th commission pair is valid
+                    case 1 {
+                        commissionData := mload(sub(add(encodedCommissionInfo, bytesLength), add(0x20, mul(i, 0x20)))) // load the i-th last bytes32 of encodedCommissionInfo
+                        let flag2 := and(commissionData, _COMMISSION_FLAG_MASK)
+                        if iszero(eq(flag, flag2)) {
+                            _revertWithReason(
+                                0x00000017696e76616c696420636f6d6d697373696f6e20666c61670000000000,
+                                0x5b
+                            ) // "invalid commission flag"
+                        }
+                        mstore(
+                            add(add(0xa0, commissionInfo), mul(i, 0x40)), // 0xa0: commissionRate0, 0xa0 + 0x40 * i: i-th commissionRate
+                            shr(160, and(commissionData, _COMMISSION_RATE_MASK))
+                        ) //i-th commissionRate
+                        mstore(
+                            add(add(0xc0, commissionInfo), mul(i, 0x40)), // 0xc0: referrerAddress0, 0xc0 + 0x40 * i: i-th referrerAddress
+                            and(commissionData, _ADDRESS_MASK)
+                        ) //i-th referrerAddress
+                    }
+                    default { // if i >= referrerNum, the i-th commission pair is invalid, and erase it
+                        mstore(add(add(0xa0, commissionInfo), mul(i, 0x40)), 0) // erase i-th commissionRate
+                        mstore(add(add(0xc0, commissionInfo), mul(i, 0x40)), 0) // erase i-th referrerAddress
+                    }
+                }
+            }
+        }
+    }
+
+    // function test_commissionInfo_buildAndParse() public {
+    //     uint256[] memory commissionRates = new uint256[](4);
+    //     commissionRates[0] = 1000000;
+    //     commissionRates[1] = 2000000;
+    //     commissionRates[2] = 3000000;
+    //     commissionRates[3] = 4000000;
+    //     address[] memory referrerAddresses = new address[](4);
+    //     referrerAddresses[0] = address(0x1234567890123456789012345678900000000000);
+    //     referrerAddresses[1] = address(0x1234567890123456789012345678911111111111);
+    //     referrerAddresses[2] = address(0x1234567890123456789012345678922222222222);
+    //     referrerAddresses[3] = address(0x1234567890123456789012345678933333333333);
+    //     bytes memory commissionInfo = _buildCommissionInfoUnified(true, false, address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), true, commissionRates, referrerAddresses);
+       
+    //     console2.log("commissionInfo:");
+    //     console2.logBytes(commissionInfo);
+
+    //     CommissionInfo memory info = _parseCommissionInfo(commissionInfo);
+
+    //     console2.log("commissionInfo.isFromTokenCommission:", info.isFromTokenCommission);
+    //     console2.log("commissionInfo.isToTokenCommission:", info.isToTokenCommission);
+    //     console2.log("commissionInfo.token:", info.token);
+    //     console2.log("commissionInfo.isToBCommission:", info.isToBCommission);
+    //     console2.log("commissionInfo.commissionLength:", info.commissionLength);
+    //     console2.log("commissionInfo.commissionRate:", info.commissionRate);
+    //     console2.log("commissionInfo.referrerAddress:", info.referrerAddress);
+    //     console2.log("commissionInfo.commissionRate2:", info.commissionRate2);
+    //     console2.log("commissionInfo.referrerAddress2:", info.referrerAddress2);
+    //     console2.log("commissionInfo.commissionRate3:", info.commissionRate3);
+    //     console2.log("commissionInfo.referrerAddress3:", info.referrerAddress3);
+    //     console2.log("commissionInfo.commissionRate4:", info.commissionRate4);
+    //     console2.log("commissionInfo.referrerAddress4:", info.referrerAddress4);
+    // }
+}

--- a/test/dexRouter/common/TrimAndCommissionTestBase.t.sol
+++ b/test/dexRouter/common/TrimAndCommissionTestBase.t.sol
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "@dex/DexRouter.sol";
+import "@dex/TokenApprove.sol";
+import "@dex/TokenApproveProxy.sol";
+import "@dex/utils/WNativeRelayer.sol";
+import "@dex/libraries/SafeERC20.sol";
+import "@dex/adapter/UniAdapter.sol";
+import "./CommissionHelper.t.sol";
+import "./TrimHelper.t.sol";
+
+interface ISafeMoon {
+    function owner() external view returns (address);
+    function updateBuyFees(uint256 _marketingFee, uint256 _liquidityFee, uint256 _devFee) external;
+    function updateSellFees(uint256 _marketingFee, uint256 _liquidityFee, uint256 _devFee) external;
+    function buyTotalFees() external view returns (uint256);
+    function sellTotalFees() external view returns (uint256);
+}
+
+contract TrimAndCommissionTestBase is Test, CommissionHelper, TrimHelper {
+    // tokens
+    address constant ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // decimals=18
+    address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // decimals=6
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // decimals=6
+    address constant SAFEMOON = 0xE253Be149830bcE1a6Af3BE399f3a952eabe127E; // Tax token, UniswapV2 pool always takes fee for sell and buy, decimals=18
+
+    // pools
+    address constant WETH_USDT_UNIV2 = 0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852;
+    address constant WETH_USDT_UNIV3 = 0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36;
+    address constant USDC_WETH_UNIV2 = 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc;
+    address constant USDC_WETH_UNIV3 = 0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640;
+    address constant WETH_SAFEMOON_UNIV2 = 0xd2e185A9076d33BD76cE548961EE6E9cB700BA17;
+
+    // users
+    address public admin = vm.rememberKey(1);
+    address public arnaud = vm.rememberKey(11111111111111111111);
+    address public trimAddress = vm.rememberKey(22222222222222222222);
+    address public chargeAddress = vm.rememberKey(33333333333333333333);
+    address[] public referrerAddresses = new address[](8);
+    
+    // contracts
+    DexRouter public dexRouter;
+    TokenApprove tokenApprove = TokenApprove(0x40aA958dd87FC8305b97f2BA922CDdCa374bcD7f); // ETH
+    TokenApproveProxy tokenApproveProxy = TokenApproveProxy(0x70cBb871E8f30Fc8Ce23609E9E0Ea87B6b222F58); // ETH
+    WNativeRelayer wNativeRelayer = WNativeRelayer(payable(0x5703B683c7F928b721CA95Da988d73a3299d4757)); // ETH
+
+    address constant UniversalUniV3Adapter = 0x6747BcaF9bD5a5F0758Cbe08903490E45DdfACB5;
+    address public UniV2Adapter;
+
+    uint256 public oneEther = 1 * 10 ** 18;
+
+    struct SwapInfo {
+        uint256 orderId;
+        DexRouter.BaseRequest baseRequest;
+        uint256[] batchesAmount;
+        DexRouter.RouterPath[][] batches;
+        PMMLib.PMMSwapRequest[] extraData;
+    }
+
+    constructor() {
+        referrerAddresses[0] = vm.rememberKey(44444444444444000000);
+        referrerAddresses[1] = vm.rememberKey(44444444444444111111);
+        referrerAddresses[2] = vm.rememberKey(44444444444444222222);
+        referrerAddresses[3] = vm.rememberKey(44444444444444333333);
+        referrerAddresses[4] = vm.rememberKey(44444444444444444444);
+        referrerAddresses[5] = vm.rememberKey(44444444444444555555);
+        referrerAddresses[6] = vm.rememberKey(44444444444444666666);
+        referrerAddresses[7] = vm.rememberKey(44444444444444777777);
+    }
+
+    modifier tokenLogAndCheck(
+        address _fromToken,
+        address _toToken,
+        uint256 _amount,
+        bool trimShouldReceive,
+        bool chargeShouldReceive,
+        bool isFromCommission,
+        bool referrer1ShouldReceive,
+        bool referrer2ShouldReceive
+    ) {
+        vm.startPrank(arnaud);
+        console2.log("User arnaud:", arnaud);
+        if (_fromToken == ETH) {
+            deal(address(arnaud), _amount);
+        } else {
+            deal(_fromToken, arnaud, _amount);
+            SafeERC20.safeApprove(IERC20(_fromToken), address(tokenApprove), _amount);
+        }
+        address[] memory tokens = new address[](2);
+        tokens[0] = _fromToken;
+        tokens[1] = _toToken;
+        _beforeSwapCheck(tokens);
+        _;
+        bool[] memory referrerShouldReceive = new bool[](2);
+        referrerShouldReceive[0] = referrer1ShouldReceive;
+        referrerShouldReceive[1] = referrer2ShouldReceive;
+        _afterSwapCheck(tokens, trimShouldReceive, chargeShouldReceive, isFromCommission, referrerShouldReceive);
+        vm.stopPrank();
+    }
+
+    modifier tokenLogAndCheck2(
+        address _fromToken,
+        address _toToken,
+        uint256 _amount,
+        bool trimShouldReceive,
+        bool chargeShouldReceive,
+        bool isFromCommission,
+        uint256 referrerShouldReceiveNum
+    ) {
+        vm.startPrank(arnaud);
+        console2.log("User arnaud:", arnaud);
+        if (_fromToken == ETH) {
+            deal(address(arnaud), _amount);
+        } else {
+            deal(_fromToken, arnaud, _amount);
+            SafeERC20.safeApprove(IERC20(_fromToken), address(tokenApprove), _amount);
+        }
+        address[] memory tokens = new address[](2);
+        tokens[0] = _fromToken;
+        tokens[1] = _toToken;
+        _beforeSwapCheck(tokens);
+        _;
+        bool[] memory referrerShouldReceive = new bool[](MAX_COMMISSION_MULTIPLE_NUM);
+        for (uint256 i = 0; i < referrerShouldReceiveNum; i++) {
+            referrerShouldReceive[i] = true;
+        }
+        _afterSwapCheck(tokens, trimShouldReceive, chargeShouldReceive, isFromCommission, referrerShouldReceive);
+        vm.stopPrank();
+    }
+
+    function _beforeSwapCheck(
+        address[] memory tokens
+    ) internal view {
+        console2.log("========== before swap ==========");
+        for (uint256 i = 0; i < tokens.length; i++) {
+            address token = tokens[i];
+            if (token == ETH) {
+                console2.log(
+                    "arnaud ETH balance before: %d",
+                    address(arnaud).balance
+                );
+                uint256 trimBalance = address(trimAddress).balance;
+                console2.log("trim ETH balance before: %d", trimBalance);
+                require(trimBalance == 0, "trim ETH balance before should be 0");
+                uint256 chargeBalance = address(chargeAddress).balance;
+                console2.log("charge ETH balance before: %d", chargeBalance);
+                require(chargeBalance == 0, "charge ETH balance before should be 0");
+                for (uint256 j = 0; j < referrerAddresses.length; j++) {
+                    uint256 referrerBalance = address(referrerAddresses[j]).balance;
+                    console2.log("referrer%d ETH balance before: %d", j, referrerBalance);
+                    require(referrerBalance == 0, "referrer ETH balance before should be 0");
+                }
+            } else {
+                console2.log(
+                    "%s balance before: %d",
+                    IERC20(token).symbol(),
+                    IERC20(token).balanceOf(address(arnaud))
+                );
+                uint256 trimBalance = IERC20(token).balanceOf(address(trimAddress));
+                console2.log("trim %s balance before: %d", IERC20(token).symbol(), trimBalance);
+                require(trimBalance == 0, "trim balance before should be 0");
+                uint256 chargeBalance = IERC20(token).balanceOf(address(chargeAddress));
+                console2.log("charge %s balance before: %d", IERC20(token).symbol(), chargeBalance);
+                require(chargeBalance == 0, "charge balance before should be 0");
+                for (uint256 j = 0; j < referrerAddresses.length; j++) {
+                    uint256 referrerBalance = IERC20(token).balanceOf(address(referrerAddresses[j]));
+                    console2.log("referrer%d %s balance before: %d", j, IERC20(token).symbol(), referrerBalance);
+                    require(referrerBalance == 0, "referrer balance before should be 0");
+                }
+            }
+        }
+    }
+
+    function _afterSwapCheck(
+        address[] memory tokens,
+        bool trimShouldReceive,
+        bool chargeShouldReceive,
+        bool isFromCommission,
+        bool[] memory referrerShouldReceive
+    ) internal view {
+        console2.log("========== after swap ==========");
+        for (uint256 i = 0; i < tokens.length; i++) {
+            address token = tokens[i];
+            if (token == ETH) {
+                console2.log("arnaud ETH balance after: %d", address(arnaud).balance);
+                uint256 trimBalance = address(trimAddress).balance;
+                console2.log("trim ETH balance after: %d", trimBalance);
+                // Only when token is toToken, then check with shouldReceive flag.
+                if (i == 1) {
+                    require(
+                        (trimShouldReceive && trimBalance > 0) || (!trimShouldReceive && trimBalance == 0),
+                        "trim1 ETH balance error after swap"
+                    );
+                }
+                uint256 chargeBalance = address(chargeAddress).balance;
+                console2.log("charge ETH balance after: %d", chargeBalance);
+                if (i == 1) {
+                    require(
+                        (chargeShouldReceive && chargeBalance > 0) || (!chargeShouldReceive && chargeBalance == 0),
+                        "charge ETH balance error after swap"
+                    );
+                }
+                for (uint256 j = 0; j < referrerShouldReceive.length; j++) {
+                    uint256 referrerBalance = address(referrerAddresses[j]).balance;
+                    console2.log("referrer%d ETH balance after: %d", j, referrerBalance);
+                    // Only when isFromCommission==true and token is fromToken, or isFromCommission==false and token is toToken, then check with shouldReceive flag.
+                    if ((i == 0 && isFromCommission) || (i == 1 && !isFromCommission)) {
+                        require(
+                            (referrerShouldReceive[j] && referrerBalance > 0) || (!referrerShouldReceive[j] && referrerBalance == 0),
+                            "referrer ETH balance error after swap"
+                        );
+                    }
+                }
+            } else {
+                console2.log("%s balance after: %d", IERC20(token).symbol(), IERC20(token).balanceOf(address(arnaud)));
+                uint256 trimBalance = IERC20(token).balanceOf(address(trimAddress));
+                console2.log("trim %s balance after: %d", IERC20(token).symbol(), trimBalance);
+                if (i == 1) {
+                    require(
+                        (trimShouldReceive && trimBalance > 0) || (!trimShouldReceive && trimBalance == 0),
+                        "trim balance error after swap"
+                    );
+                }
+                uint256 chargeBalance = IERC20(token).balanceOf(address(chargeAddress));
+                console2.log("charge %s balance after: %d", IERC20(token).symbol(), chargeBalance);
+                if (i == 1) {
+                    require(
+                        (chargeShouldReceive && chargeBalance > 0) || (!chargeShouldReceive && chargeBalance == 0),
+                        "charge balance error after swap"
+                    );
+                }
+                for (uint256 j = 0; j < referrerShouldReceive.length; j++) {
+                    uint256 referrerBalance = IERC20(token).balanceOf(address(referrerAddresses[j]));
+                    console2.log("referrer%d %s balance after: %d", j, IERC20(token).symbol(), referrerBalance);
+                    // Only when isFromCommission==true and token is fromToken, or isFromCommission==false and token is toToken, then check with shouldReceive flag.
+                    if ((i == 0 && isFromCommission) || (i == 1 && !isFromCommission)) {
+                        require(
+                            (referrerShouldReceive[j] && referrerBalance > 0) || (!referrerShouldReceive[j] && referrerBalance == 0),
+                            "referrer balance error after swap"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    function setUp() public virtual {
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"), 23293873); // 2025.9.5 10:18
+        vm.startPrank(admin);
+        UniV2Adapter = address(new UniAdapter());
+        dexRouter = new DexRouter();
+        vm.stopPrank();
+        address wNativeRelayerOwner = wNativeRelayer.owner();
+        vm.startPrank(wNativeRelayerOwner);
+        tokenApproveProxy.addProxy(address(dexRouter));
+        address[] memory whitelistedCallers = new address[](1);
+        whitelistedCallers[0] = address(dexRouter);
+        wNativeRelayer.setCallerOk(whitelistedCallers, true);
+        vm.stopPrank();
+        address safeMoonOwner = ISafeMoon(SAFEMOON).owner();
+        vm.startPrank(safeMoonOwner);
+        ISafeMoon(SAFEMOON).updateBuyFees(10, 0, 0);
+        ISafeMoon(SAFEMOON).updateSellFees(20, 0, 0);
+        vm.stopPrank();
+        // console2.log("safeMoon buy fees: %d", ISafeMoon(SAFEMOON).buyTotalFees());
+        // console2.log("safeMoon sell fees: %d", ISafeMoon(SAFEMOON).sellTotalFees());
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateBaseRequest(
+        address _fromToken,
+        address _toToken,
+        uint256 _amount
+    ) internal view returns (DexRouter.BaseRequest memory baseRequest) {
+        baseRequest.fromToken = uint256(uint160(_fromToken));
+        baseRequest.toToken = _toToken;
+        baseRequest.fromTokenAmount = _amount;
+        baseRequest.minReturnAmount = 0;
+        baseRequest.deadLine = block.timestamp + 1000;
+    }
+
+    function _generate1TrimOnlyTrimData() internal view returns (bytes memory) {
+        return _buildTrimInfoUnified(
+            50, // trimRate 5%
+            trimAddress, // trimAddress
+            100, // expectAmountOut 100, but usually the trimAmount will be the allowedMaxTrimAmount cause the expectAmountOut is too small
+            0, // chargeRate 0%, all for trim
+            address(0), // chargeAddress,
+            false // isToBTrim
+        );
+    }
+
+    function _generate1TrimOnlyChargeData() internal view returns (bytes memory) {
+        return _buildTrimInfoUnified(
+            50, // trimRate 5%
+            address(0), // trimAddress
+            100, // expectAmountOut 100, but usually the trimAmount will be the allowedMaxTrimAmount cause the expectAmountOut is too small
+            1000, // chargeRate 100%, all for charge
+            chargeAddress, // chargeAddress,
+            false // isToBTrim
+        );
+    }
+
+    function _generate2TrimData() internal view returns (bytes memory) {
+        return _buildTrimInfoUnified(
+            50, // trimRate 5%
+            trimAddress, // trimAddress
+            100, // expectAmountOut 100, but usually the trimAmount will be the allowedMaxTrimAmount cause the expectAmountOut is too small
+            400, // chargeRate 40% of trimAmount (400 / 1000)
+            chargeAddress, // chargeAddress,
+            true // isToBTrim
+        );
+    }
+
+    function _generate1CommissionData(bool isFromTokenCommission, address token) internal view returns (bytes memory) {
+        uint256[] memory commissionRates_ = new uint256[](1);
+        commissionRates_[0] = 1000000;
+        address[] memory referrerAddresses_ = new address[](1);
+        referrerAddresses_[0] = referrerAddresses[0];
+        return _buildCommissionInfoUnified(
+            isFromTokenCommission, // isFromTokenCommission
+            !isFromTokenCommission, // isToTokenCommission
+            token, // token
+            false, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+    }
+
+    function _generate2CommissionData(bool isFromTokenCommission, address token) internal view returns (bytes memory) {
+        uint256[] memory commissionRates_ = new uint256[](2);
+        commissionRates_[0] = 1000000;
+        commissionRates_[1] = 1000000;
+        address[] memory referrerAddresses_ = new address[](2);
+        referrerAddresses_[0] = referrerAddresses[0];
+        referrerAddresses_[1] = referrerAddresses[1];
+        return _buildCommissionInfoUnified(
+            isFromTokenCommission, // isFromTokenCommission
+            !isFromTokenCommission, // isToTokenCommission
+            token, // token
+            false, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+    }
+
+    function _generateMultipleCommissionData(bool isFromTokenCommission, address token, bool isToBCommission, uint256 referrerNum) internal view returns (bytes memory) {
+        uint256[] memory commissionRates_ = new uint256[](referrerNum);
+        address[] memory referrerAddresses_ = new address[](referrerNum);
+        for (uint256 i = 0; i < referrerNum; i++) {
+            commissionRates_[i] = 1000000;
+            referrerAddresses_[i] = referrerAddresses[i];
+        }
+        return _buildCommissionInfoUnified(
+            isFromTokenCommission, // isFromTokenCommission
+            !isFromTokenCommission, // isToTokenCommission
+            token, // token
+            isToBCommission, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+    }
+}

--- a/test/dexRouter/common/TrimHelper.t.sol
+++ b/test/dexRouter/common/TrimHelper.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TrimHelper {
+    uint256 internal constant TRIM_FLAG =
+        0x7777777711110000000000000000000000000000000000000000000000000000;
+    uint256 internal constant TRIM_DUAL_FLAG =
+        0x7777777722220000000000000000000000000000000000000000000000000000;
+
+    /*
+     *  Trim data should be encoded after method calldata and before commission data, the size may be 64 or 96 bytes.
+     *  Single Trim:
+     *  ┌─────────────┬─────────────┬─────────────────┬─────────────┬─────────────┬─────────────────┐
+     *  │ trim_flag   │ padding     │ expect_amount   │ trim_flag   │ trim_rate   │ trim_address    │
+     *  │ 6 bytes     │ 6 bytes     │ 20 bytes        │ 6 bytes     │ 6 bytes     │ 20 bytes        │
+     *  │0x777777771111│0x000000000000│               │0x777777771111│            │                 │
+     *  └─────────────┴─────────────┴─────────────────┴─────────────┴─────────────┴─────────────────┘
+     *  ←──────────────--- 32 bytes ---──────────────→ ←──────────────--- 32 bytes ---──────────────→
+     *  Dual Trim:
+     *  ┌─────────────┬─────────────┬─────────────────┬─────────────┬─────────────┬─────────────────┬─────────────┬─────────────┬─────────────────┐
+     *  │ trim_flag   │ charge_rate │ charge_address  │ trim_flag   │ padding     │ expect_amount   │ trim_flag   │ trim_rate   │ trim_address    │
+     *  │ 6 bytes     │ 6 bytes     │ 20 bytes        │ 6 bytes     │ 6 bytes     │ 20 bytes        │ 6 bytes     │ 6 bytes     │ 20 bytes        │
+     *  │0x777777772222│            │                 │0x777777772222│0x800000000000│               │0x777777772222│            │                 │
+     *  └─────────────┴─────────────┴─────────────────┴─────────────┴─────────────┴─────────────────┴─────────────┴─────────────┴─────────────────┘
+     *  ←──────────────--- 32 bytes ---──────────────→ ←──────────────--- 32 bytes --──────────────→ ←──────────────--- 32 bytes ---──────────────→
+     *  For both single and dual trim, isToBTrim flag is encoded in padding of the second bytes32.
+     *  - If isToBTrim is true, the padding is 0x800000000000.
+     *  - If isToBTrim is false, the padding is 0x000000000000.
+    */
+
+    struct TrimInfo {
+        bool hasTrim; // 0x00
+        uint256 trimRate; // 0x20
+        address trimAddress; // 0x40
+        uint256 expectAmountOut; // 0x60
+        uint256 chargeRate; // 0x80
+        address chargeAddress; // 0xa0
+    }
+
+    function _buildTrimInfoUnified(
+        uint256 trimRate,
+        address trimAddress,
+        uint256 expectAmountOut,
+        uint256 chargeRate,
+        address chargeAddress,
+        bool isToBTrim
+    ) internal pure returns (bytes memory) {
+        // ensure trimRate and chargeRate are valid
+        require(trimRate > 0 && trimRate <= 1000);
+        require(chargeRate <= 1000);
+        // ensure chargeRate and address are valid
+        require(
+            (chargeRate == 0 && chargeAddress == address(0)) ||
+            (chargeRate == 1000 && trimAddress == address(0)) ||
+            ((chargeRate > 0 && chargeRate < 1000) && trimAddress != address(0) && chargeAddress != address(0))
+        );
+        uint256 toBTrimValue = isToBTrim ? (1 << 207) : 0;
+        if (chargeRate == 0) {
+            return abi.encodePacked(
+                bytes32(
+                    (TRIM_FLAG & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                    toBTrimValue |
+                    (uint256(expectAmountOut) & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+                ),
+                bytes32(
+                    (TRIM_FLAG & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                    ((uint256(trimRate) << 160) &    0x000000000000ffffffffffff0000000000000000000000000000000000000000) |
+                    (uint256(uint160(trimAddress)) & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+                )
+            );
+        } else {
+            return abi.encodePacked(
+                bytes32(
+                    (TRIM_DUAL_FLAG & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                    ((uint256(chargeRate) << 160) & 0x000000000000ffffffffffff0000000000000000000000000000000000000000) |
+                    (uint256(uint160(chargeAddress)) & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+                ),
+                bytes32(
+                    (TRIM_DUAL_FLAG & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                    toBTrimValue |
+                    (uint256(expectAmountOut) & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+                ),
+                bytes32(
+                    (TRIM_DUAL_FLAG & 0xffffffffffff0000000000000000000000000000000000000000000000000000) |
+                    ((uint256(trimRate) << 160) & 0x000000000000ffffffffffff0000000000000000000000000000000000000000) |
+                    (uint256(uint160(trimAddress)) & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff)
+                )
+            );
+        }
+    }
+
+    function _parseTrimInfo(bytes memory trimInfo) internal pure returns (TrimInfo memory) {
+        uint256 length = trimInfo.length;
+        require(length == 64 || length == 96, "Invalid trim info length");
+        TrimInfo memory info;
+        bytes32 firstBytes;
+        assembly {
+            firstBytes := mload(add(trimInfo, length))
+        }
+        uint256 firstValue = uint256(firstBytes);
+        uint256 flag = firstValue & 0xffffffffffff0000000000000000000000000000000000000000000000000000;
+        info.hasTrim = ((flag == TRIM_FLAG || flag == TRIM_DUAL_FLAG));
+        if (info.hasTrim) {
+            info.trimRate = (firstValue >> 160) & 0xffffffffffff;
+            info.trimAddress = address(uint160(firstValue & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff));
+            bytes32 secondBytes;
+            assembly {
+                secondBytes := mload(sub(add(trimInfo, length), 32))
+            }
+            uint256 secondValue = uint256(secondBytes);
+            info.expectAmountOut = secondValue & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff;
+        }
+        if (flag == TRIM_DUAL_FLAG) {
+            bytes32 thirdBytes;
+            assembly {
+                thirdBytes := mload(sub(add(trimInfo, length), 64))
+            }
+            uint256 thirdValue = uint256(thirdBytes);
+            info.chargeRate = (thirdValue >> 160) & 0xffffffffffff;
+            info.chargeAddress = address(uint160(thirdValue & 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff));
+        }
+        return info;
+    }
+}

--- a/test/dexRouter/multiCommission/SmartSwapMultiCommissionTest.t.sol
+++ b/test/dexRouter/multiCommission/SmartSwapMultiCommissionTest.t.sol
@@ -1,0 +1,946 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+/*
+ * The smartSwap method is tested with condition1 * condition2 + condition3 * condition4:
+ * condition1:
+ *     (1) ERC20 -> ERC20
+ *     (2) ETH -> ERC20
+ *     (3) ERC20 -> ETH
+ * condition2:
+ *     (1) 8fromCommission + noTrim
+ *     (2) 8toCommission + noTrim
+ *     (3) 3fromCommission + 1trimOnlyTrim
+ *     (4) 3toCommission + 1trimOnlyTrim
+ *     (5) 3fromCommission + 1trimOnlyCharge
+ *     (6) 3toCommission + 1trimOnlyCharge
+ *     (7) 3fromCommission + 2trim
+ *     (8) 3toCommission + 2trim
+ *     (9) 8fromCommission + 1trimOnlyTrim
+ *     (10) 8toCommission + 1trimOnlyTrim
+ *     (11) 8fromCommission + 1trimOnlyCharge
+ *     (12) 8toCommission + 1trimOnlyCharge
+ *     (13) 8fromCommission + 2trim
+ *     (14) 8toCommission + 2trim
+ *     (15) 8fromCommissionToB + 2trim
+ *     (16) 8toCommissionToB + 2trim
+ * condition3:
+ *     (1) ERC20 -> TaxToken(SAFEMOON)
+ *     (2) TaxToken(SAFEMOON) -> ERC20
+ * condition4:
+ *     (1) 8fromCommission + noTrim
+ *     (2) 8toCommission + noTrim
+ *     (3) 3fromCommission + 2trim
+ *     (4) 3toCommission + 2trim
+ *     (5) 8fromCommission + 2trim
+ *     (6) 8toCommission + 2trim
+*/
+
+contract SmartSwapMultiCommissionTest is TrimAndCommissionTestBase {
+    // ==================== ERC20->ERC20 ====================
+    // (1) WETH->USDT with 8fromCommission and noTrim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8fromCommission_noTrim() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, false, false, true, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (2) WETH->USDT with 8toCommission and noTrim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8toCommission_noTrim() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, false, false, false, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (3) WETH->USDT with 3fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_WETH2USDT_3fromCommission_1trimOnlyTrim() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, true, false, true, 3) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // (4) WETH->USDT with 3toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_WETH2USDT_3toCommission_1trimOnlyTrim() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, true, false, false, 3) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    // (5) WETH->USDT with 3fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_WETH2USDT_3fromCommission_1trimOnlyCharge() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, false, true, true, 3) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (6) WETH->USDT with 3toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_WETH2USDT_3toCommission_1trimOnlyCharge() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, false, true, false, 3) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (7) WETH->USDT with 3fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2USDT_3fromCommission_2trim() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, true, true, true, 3) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (8) WETH->USDT with 3toCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2USDT_3toCommission_2trim() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, true, true, false, 3) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (9) WETH->USDT with 8fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8fromCommission_1trimOnlyTrim() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, true, false, true, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (10) WETH->USDT with 8toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8toCommission_1trimOnlyTrim() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, true, false, false, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (11) WETH->USDT with 8fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_WETH2USDT_8fromCommission_1trimOnlyCharge() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, false, true, true, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    // (12) WETH->USDT with 8toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_WETH2USDT_8toCommission_1trimOnlyCharge() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, false, true, false, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    // (13) WETH->USDT with 8fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8fromCommission_2trim() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, true, true, true, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    // (14) WETH->USDT with 8toCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8toCommission_2trim() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, true, true, false, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (15) WETH->USDT with 8fromCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8fromCommissionToB_2trim() tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, true, true, true, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (16) WETH->USDT with 8toCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_WETH2USDT_8toCommissionToB_2trim() tokenLogAndCheck2(WETH, USDT, 1 * 10 ** 18, true, true, false, 8) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (17) USDT->WETH with 8fromCommission and noTrim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8fromCommission_noTrim() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, false, false, true, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (18) USDT->WETH with 8toCommission and noTrim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8toCommission_noTrim() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, false, false, false, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (19) USDT->WETH with 3fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2WETH_3fromCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, true, false, true, 3) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (20) USDT->WETH with 3toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2WETH_3toCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, true, false, false, 3) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (21) USDT->WETH with 3fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2WETH_3fromCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, false, true, true, 3) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (22) USDT->WETH with 3toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2WETH_3toCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, false, true, false, 3) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (23) USDT->WETH with 3fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2WETH_3fromCommission_2trim() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, true, true, true, 3) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (24) USDT->WETH with 3toCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2WETH_3toCommission_2trim() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, true, true, false, 3) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (25) USDT->WETH with 8fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8fromCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, true, false, true, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (26) USDT->WETH with 8toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8toCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, true, false, false, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (27) USDT->WETH with 8fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2WETH_8fromCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, false, true, true, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (28) USDT->WETH with 8toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2WETH_8toCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, false, true, false, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (29) USDT->WETH with 8fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8fromCommission_2trim() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, true, true, true, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (30) USDT->WETH with 8toCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8toCommission_2trim() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, true, true, false, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (31) USDT->WETH with 8fromCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8fromCommissionToB_2trim() tokenLogAndCheck2(USDT, WETH, 2000 * 10 ** 6, true, true, true, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (32) USDT->WETH with 8toCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_USDT2WETH_8toCommissionToB_2trim() tokenLogAndCheck2(USDT, WETH, 1000 * 10 ** 6, true, true, false, 8) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ETH->ERC20 ====================
+    // (1) ETH->USDT with 8fromCommission and noTrim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8fromCommission_noTrim() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, false, false, true, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (2) ETH->USDT with 8toCommission and noTrim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8toCommission_noTrim() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, false, false, false, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+    
+    // (3) ETH->USDT with 3fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_ETH2USDT_3fromCommission_1trimOnlyTrim() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, true, false, true, 3) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (4) ETH->USDT with 3toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_ETH2USDT_3toCommission_1trimOnlyTrim() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, true, false, false, 3) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (5) ETH->USDT with 3fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_ETH2USDT_3fromCommission_1trimOnlyCharge() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, false, true, true, 3) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (6) ETH->USDT with 3toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_ETH2USDT_3toCommission_1trimOnlyCharge() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, false, true, false, 3) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (7) ETH->USDT with 3fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_ETH2USDT_3fromCommission_2trim() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, true, true, true, 3) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (8) ETH->USDT with 3toCommission and 2trim
+    function test_multiCommission_smartSwapTo_ETH2USDT_3toCommission_2trim() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, true, true, false, 3) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (9) ETH->USDT with 8fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8fromCommission_1trimOnlyTrim() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, true, false, true, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (10) ETH->USDT with 8toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8toCommission_1trimOnlyTrim() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, true, false, false, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (11) ETH->USDT with 8fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_ETH2USDT_8fromCommission_1trimOnlyCharge() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, false, true, true, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (12) ETH->USDT with 8toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_ETH2USDT_8toCommission_1trimOnlyCharge() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, false, true, false, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (13) ETH->USDT with 8fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8fromCommission_2trim() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, true, true, true, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (14) ETH->USDT with 8toCommission and 2trim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8toCommission_2trim() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, true, true, false, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (15) ETH->USDT with 8fromCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8fromCommissionToB_2trim() tokenLogAndCheck2(ETH, USDT, 2 * 10 ** 18, true, true, true, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, ETH, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // (16) ETH->USDT with 8toCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_ETH2USDT_8toCommissionToB_2trim() tokenLogAndCheck2(ETH, USDT, 1 * 10 ** 18, true, true, false, 8) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, USDT, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 1 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ERC20->ETH ====================
+    // (1) USDT->ETH with 8fromCommission and noTrim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8fromCommission_noTrim() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, false, false, true, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (2) USDT->ETH with 8toCommission and noTrim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8toCommission_noTrim() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, false, false, false, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (3) USDT->ETH with 3fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2ETH_3fromCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, true, false, true, 3) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (4) USDT->ETH with 3toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2ETH_3toCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, true, false, false, 3) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (5) USDT->ETH with 3fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2ETH_3fromCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, false, true, true, 3) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (6) USDT->ETH with 3toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2ETH_3toCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, false, true, false, 3) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 3);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (7) USDT->ETH with 3fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2ETH_3fromCommission_2trim() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, true, true, true, 3) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (8) USDT->ETH with 3toCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2ETH_3toCommission_2trim() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, true, true, false, 3) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (9) USDT->ETH with 8fromCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8fromCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, true, false, true, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (10) USDT->ETH with 8toCommission and 1trimOnlyTrim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8toCommission_1trimOnlyTrim() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, true, false, false, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (11) USDT->ETH with 8fromCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2ETH_8fromCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, false, true, true, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (12) USDT->ETH with 8toCommission and 1trimOnlyCharge
+    function test_multiCommission_smartSwapTo_USDT2ETH_8toCommission_1trimOnlyCharge() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, false, true, false, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 8);
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (13) USDT->ETH with 8fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8fromCommission_2trim() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, true, true, true, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (14) USDT->ETH with 8toCommission and 2trim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8toCommission_2trim() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, true, true, false, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (15) USDT->ETH with 8fromCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8fromCommissionToB_2trim() tokenLogAndCheck2(USDT, ETH, 2000 * 10 ** 6, true, true, true, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, USDT, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (16) USDT->ETH with 8toCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_USDT2ETH_8toCommissionToB_2trim() tokenLogAndCheck2(USDT, ETH, 1000 * 10 ** 6, true, true, false, 8) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, ETH, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ERC20->TaxToken(SAFEMOON) ====================
+    // (1) ERC20->TaxToken(SAFEMOON) with 8fromCommission and noTrim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_8fromCommission_noTrim() tokenLogAndCheck2(WETH, SAFEMOON, 0.02 * 10 ** 18, false, false, true, 8) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (2) ERC20->TaxToken(SAFEMOON) with 8toCommission and noTrim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_8toCommission_noTrim() tokenLogAndCheck2(WETH, SAFEMOON, 0.01 * 10 ** 18, false, false, false, 8) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, SAFEMOON, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (3) ERC20->TaxToken(SAFEMOON) with 3fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_3fromCommission_2trim() tokenLogAndCheck2(WETH, SAFEMOON, 0.02 * 10 ** 18, true, true, true, 3) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (4) ERC20->TaxToken(SAFEMOON) with 3toCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_3toCommission_2trim() tokenLogAndCheck2(WETH, SAFEMOON, 0.01 * 10 ** 18, true, true, false, 3) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, SAFEMOON, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (5) ERC20->TaxToken(SAFEMOON) with 8fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_8fromCommission_2trim() tokenLogAndCheck2(WETH, SAFEMOON, 0.02 * 10 ** 18, true, true, true, 8) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (6) ERC20->TaxToken(SAFEMOON) with 8toCommission and 2trim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_8toCommission_2trim() tokenLogAndCheck2(WETH, SAFEMOON, 0.01 * 10 ** 18, true, true, false, 8) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, SAFEMOON, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (7) ERC20->TaxToken(SAFEMOON) with 8fromCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_8fromCommissionToB_2trim() tokenLogAndCheck2(WETH, SAFEMOON, 0.02 * 10 ** 18, true, true, true, 8) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, WETH, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (8) ERC20->TaxToken(SAFEMOON) with 8toCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_WETH2SAFEMOON_8toCommissionToB_2trim() tokenLogAndCheck2(WETH, SAFEMOON, 0.01 * 10 ** 18, true, true, false, 8) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, SAFEMOON, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== TaxToken(SAFEMOON)->ERC20 ====================
+    // (1) TaxToken(SAFEMOON)->ERC20 with 8fromCommission and noTrim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_8fromCommission_noTrim() tokenLogAndCheck2(SAFEMOON, WETH, 2 * 10 ** 27, false, false, true, 8) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, SAFEMOON, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (2) TaxToken(SAFEMOON)->ERC20 with 8toCommission and noTrim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_8toCommission_noTrim() tokenLogAndCheck2(SAFEMOON, WETH, 1 * 10 ** 27, false, false, false, 8) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 8);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (3) TaxToken(SAFEMOON)->ERC20 with 3fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_3fromCommission_2trim() tokenLogAndCheck2(SAFEMOON, WETH, 2 * 10 ** 27, true, true, true, 3) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, SAFEMOON, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (4) TaxToken(SAFEMOON)->ERC20 with 3toCommission and 2trim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_3toCommission_2trim() tokenLogAndCheck2(SAFEMOON, WETH, 1 * 10 ** 27, true, true, false, 3) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 3);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (5) TaxToken(SAFEMOON)->ERC20 with 8fromCommission and 2trim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_8fromCommission_2trim() tokenLogAndCheck2(SAFEMOON, WETH, 2 * 10 ** 27, true, true, true, 8) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, SAFEMOON, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (6) TaxToken(SAFEMOON)->ERC20 with 8toCommission and 2trim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_8toCommission_2trim() tokenLogAndCheck2(SAFEMOON, WETH, 1 * 10 ** 27, true, true, false, 8) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, false, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (7) TaxToken(SAFEMOON)->ERC20 with 8fromCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_8fromCommissionToB_2trim() tokenLogAndCheck2(SAFEMOON, WETH, 2 * 10 ** 27, true, true, true, 8) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(true, SAFEMOON, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // (8) TaxToken(SAFEMOON)->ERC20 with 8toCommissionToB and 2trim
+    function test_multiCommission_smartSwapTo_SAFEMOON2WETH_8toCommissionToB_2trim() tokenLogAndCheck2(SAFEMOON, WETH, 1 * 10 ** 27, true, true, false, 8) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generateMultipleCommissionData(false, WETH, true, 8);
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateWETH2USDTSmartSwapData() internal view returns (bytes memory) {
+        return _generateSmartSwapData(
+            WETH,
+            USDT,
+            oneEther,
+            address(UniversalUniV3Adapter),
+            address(UniversalUniV3Adapter),
+            false,
+            address(WETH_USDT_UNIV3),
+            abi.encode(0, abi.encode(WETH, USDT, 0))
+        );
+    }
+
+    function _generateUSDT2WETHSmartSwapData() internal view returns (bytes memory) {
+        return _generateSmartSwapData(
+            USDT,
+            WETH,
+            1000 * 10 ** 6,
+            address(UniversalUniV3Adapter),
+            address(UniversalUniV3Adapter),
+            false,
+            address(WETH_USDT_UNIV3),
+            abi.encode(0, abi.encode(USDT, WETH, 0))
+        );
+    }
+
+    function _generateETH2USDTSmartSwapData() internal view returns (bytes memory) {
+        return _generateSmartSwapData(
+            ETH,
+            USDT,
+            oneEther,
+            address(UniversalUniV3Adapter),
+            address(UniversalUniV3Adapter),
+            false,
+            address(WETH_USDT_UNIV3),
+            abi.encode(0, abi.encode(WETH, USDT, 0))
+        );
+    }
+
+    function _generateUSDT2ETHSmartSwapData() internal view returns (bytes memory) {
+        return _generateSmartSwapData(
+            USDT,
+            ETH,
+            1000 * 10 ** 6,
+            address(UniversalUniV3Adapter),
+            address(UniversalUniV3Adapter),
+            true,
+            address(WETH_USDT_UNIV3),
+            abi.encode(0, abi.encode(USDT, WETH, 0))
+        );
+    }
+
+    function _generateWETH2SAFEMOONSmartSwapData() internal view returns (bytes memory) {
+        return _generateSmartSwapData(
+            WETH,
+            SAFEMOON,
+            0.01 * 10 ** 18,
+            address(WETH_SAFEMOON_UNIV2),
+            address(UniV2Adapter),
+            false,
+            address(WETH_SAFEMOON_UNIV2),
+            "0x"
+        );
+    }
+
+    function _generateSAFEMOON2WETHSmartSwapData() internal view returns (bytes memory) {
+        return _generateSmartSwapData(
+            SAFEMOON,
+            WETH,
+            1 * 10 ** 27,
+            address(WETH_SAFEMOON_UNIV2),
+            address(UniV2Adapter),
+            true,
+            address(WETH_SAFEMOON_UNIV2),
+            "0x"
+        );
+    }
+
+    function _generateSmartSwapData(
+        address fromToken,
+        address toToken,
+        uint256 fromTokenAmount,
+        address assetTo,
+        address adapter,
+        bool isReverse,
+        address poolAddress,
+        bytes memory extraData
+    ) internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(fromToken, toToken, fromTokenAmount);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = fromTokenAmount;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = adapter;
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = assetTo;
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(isReverse ? 0x80 : 0x00), uint88(10000), poolAddress)));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = extraData;
+        swapInfo.batches[0][0].fromToken = uint256(uint160(fromToken == ETH ? WETH : fromToken));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+}

--- a/test/dexRouter/trim/CommissionAndTrimRoundingTest.t.sol
+++ b/test/dexRouter/trim/CommissionAndTrimRoundingTest.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+contract CommissionAndTrimRoundingTest is TrimAndCommissionTestBase {
+    // Test toToken commission with commission rate 1 / 10^9, rounding result = 1, and the amount in event is 1.
+    function test_normalAmountOut_toTokenCommissionRounding_result_gt_0() tokenLogAndCheck(WETH, USDT, 3 * 10 ** 17, false, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData(3 * 10 ** 17); // 3 * 10^17 WETH -> 1,294,111,181 USDT, rounding result with 1/10^9 is 1.
+        uint256[] memory commissionRates_ = new uint256[](1);
+        commissionRates_[0] = 1;
+        address[] memory referrerAddresses_ = new address[](1);
+        referrerAddresses_[0] = referrerAddresses[0];
+        bytes memory commissionData = _buildCommissionInfoUnified(
+            false, // isFromTokenCommission
+            true, // isToTokenCommission
+            USDT, // token
+            false, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+        // USDT balance of user is 1,294,111,180
+        // USDT balance of referrerAddress is 1, and the modifier also ensure the referrerAddress balance > 0
+    }
+
+    // Test toToken commission with commission rate 1 / 10^9, the rounding result = 0, and the amount in event is 0
+    function test_normalAmountOut_toTokenCommissionRounding_result_eq_0() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 17, false, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData(2 * 10 ** 17); // 2 * 10^17 WETH -> 862,740,908 USDT, rounding result with 1/10^9 is 0.
+        uint256[] memory commissionRates_ = new uint256[](1);
+        commissionRates_[0] = 1;
+        address[] memory referrerAddresses_ = new address[](1);
+        referrerAddresses_[0] = referrerAddresses[0];
+        bytes memory commissionData = _buildCommissionInfoUnified(
+            false, // isFromTokenCommission
+            true, // isToTokenCommission
+            USDT, // token
+            false, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+        // USDT balance of user is 862,740,908
+        // USDT balance of referrerAddress is 0, and the modifier also ensure the referrerAddress balance is 0
+    }
+
+    // Test toToken commission with commission rate 1%, rounding result = 1, and the amount in event is 1.
+    function test_smallAmountOut_toTokenCommissionRounding_result_gt_0() tokenLogAndCheck(WETH, USDT, 3 * 10 ** 10, false, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData(3 * 10 ** 10); // 3 * 10^10 WETH -> 129 USDT, rounding result with 1% is 1.
+        uint256[] memory commissionRates_ = new uint256[](1);
+        commissionRates_[0] = 10000000;
+        address[] memory referrerAddresses_ = new address[](1);
+        referrerAddresses_[0] = referrerAddresses[0];
+        bytes memory commissionData = _buildCommissionInfoUnified(
+            false, // isFromTokenCommission
+            true, // isToTokenCommission
+            USDT, // token
+            false, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+        // USDT balance of user is 128
+        // USDT balance of referrerAddress is 1, and the modifier also ensure the referrerAddress balance > 0
+    }
+
+    // Test toToken commission with commission rate 1%, rounding result = 0, and the amount in event is 0.
+    function test_smallAmountOut_toTokenCommissionRounding_result_eq_0() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 10, false, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData(2 * 10 ** 10); // 2 * 10^10 WETH -> 86 USDT, rounding result with 1% is 0.
+        uint256[] memory commissionRates_ = new uint256[](1);
+        commissionRates_[0] = 10000000;
+        address[] memory referrerAddresses_ = new address[](1);
+        referrerAddresses_[0] = referrerAddresses[0];
+        bytes memory commissionData = _buildCommissionInfoUnified(
+            false, // isFromTokenCommission
+            true, // isToTokenCommission
+            USDT, // token
+            false, // isToBCommission
+            commissionRates_,
+            referrerAddresses_
+        );
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+        // USDT balance of user is 86
+        // USDT balance of referrerAddress is 0, and the modifier also ensure the referrerAddress balance is 0
+    }
+
+    // Test toToken trim with trim rate 1 / 1000, rounding result is 1, and the amount in event is 1.
+    function test_smallAmountOut_toTokenTrimRounding_result_gt_0() tokenLogAndCheck(WETH, USDT, 3 * 10 ** 11, true, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData(3 * 10 ** 11); // 3 * 10^11 WETH -> 1,294 USDT, rounding result with 1/1000 is 1.
+        bytes memory trimData = _buildTrimInfoUnified(
+            1, // trimRate 1/1000
+            trimAddress, // trimAddress
+            10, // expectAmountOut 10, but usually the trimAmount will be the allowedMaxTrimAmount cause the expectAmountOut is too small
+            0, // chargeRate 0%, all for trim
+            address(0), // chargeAddress
+            true // isToBTrim
+        );
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+        // USDT balance of user is 1,293
+        // USDT balance of referrerAddress is 1, and the modifier also ensure the referrerAddress balance > 0
+    }
+
+    // Test toToken trim with trim rate 1 / 1000, and rounding result = 0, and the amount in event is 0.
+    function test_smallAmountOut_toTokenTrimRounding_result_eq_0() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 11, false, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData(2 * 10 ** 11); // 2 * 10^11 WETH -> 862 USDT, rounding result with 1/1000 is 0.
+        bytes memory trimData = _buildTrimInfoUnified(
+            1, // trimRate 1/1000
+            trimAddress, // trimAddress
+            10, // expectAmountOut 10, but usually the trimAmount will be the allowedMaxTrimAmount cause the expectAmountOut is too small
+            0, // chargeRate 0%, all for trim
+            address(0), // chargeAddress
+            true // isToBTrim
+        );
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+        // USDT balance of user is 862
+        // USDT balance of referrerAddress is 0, and the modifier also ensure the referrerAddress balance is 0
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateWETH2USDTSmartSwapData(uint256 fromTokenAmount) internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(WETH, USDT, fromTokenAmount);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = fromTokenAmount;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_USDT_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(WETH, USDT, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(WETH));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+}

--- a/test/dexRouter/trim/DagSwapTrimTest.t.sol
+++ b/test/dexRouter/trim/DagSwapTrimTest.t.sol
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+/*
+ * The dagSwap method is tested with condition1 * condition2:
+ * condition1:
+ *     (1) ERC20 -> ERC20
+ *     (2) ETH -> ERC20
+ *     (3) ERC20 -> ETH
+ * condition2:
+ *     (1) noTrim + noCommission
+ *     (2) 1trimOnlyTrim + noCommission
+ *     (3) 1trimOnlyCharge + noCommission
+ *     (4) 2trim + noCommission
+ *     (5) 1trimOnlyTrim + 1toCommission
+ *     (6) 1trimOnlyCharge + 1toCommission
+ *     (7) 2trim + 1toCommission
+ *     (8) 1trimOnlyTrim + 2toCommission
+ *     (9) 1trimOnlyCharge + 2toCommission
+ *     (10) 2trim + 2toCommission
+ *     (11) 2trim + 2fromCommission
+*/
+contract DagSwapTrimTest is TrimAndCommissionTestBase {
+
+    // ==================== ERC20->ERC20 ====================
+    // ERC20->ERC20 with noTrim and noCommission
+    function test_trim_dagSwapTo_WETH2USDT_noTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_dagSwapTo_WETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and noCommission
+    function test_trim_dagSwapTo_WETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and noCommission
+    function test_trim_dagSwapTo_WETH2USDT_2trim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_dagSwapTo_WETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_dagSwapTo_WETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and 1toCommission
+    function test_trim_dagSwapTo_WETH2USDT_2trim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_dagSwapTo_WETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_dagSwapTo_WETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and 2toCommission
+    function test_trim_dagSwapTo_WETH2USDT_2trim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ERC20 with 2trim and 2fromCommission
+    function test_trim_dagSwapTo_WETH2USDT_2trim_2fromCommission() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateWETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ETH->ERC20 ====================
+    // ETH->ERC20 with noTrim and noCommission
+    function test_trim_dagSwapTo_ETH2USDT_noTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        (bool success, ) = address(dexRouter).call{value: oneEther}(swapData);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_dagSwapTo_ETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and noCommission
+    function test_trim_dagSwapTo_ETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and noCommission
+    function test_trim_dagSwapTo_ETH2USDT_2trim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_dagSwapTo_ETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_dagSwapTo_ETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 1toCommission
+    function test_trim_dagSwapTo_ETH2USDT_2trim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_dagSwapTo_ETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_dagSwapTo_ETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 2toCommission
+    function test_trim_dagSwapTo_ETH2USDT_2trim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+    
+    // ETH->ERC20 with 2trim and 2fromCommission
+    function test_trim_dagSwapTo_ETH2USDT_2trim_2fromCommission() tokenLogAndCheck(ETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateETH2USDTDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ERC20->ETH ====================
+    // ERC20->ETH with noTrim and noCommission
+    function test_trim_dagSwapTo_USDT2ETH_noTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, false, false, false, false)  public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and noCommission
+    function test_trim_dagSwapTo_USDT2ETH_1trimOnlyTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and noCommission
+    function test_trim_dagSwapTo_USDT2ETH_1trimOnlyCharge_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and noCommission
+    function test_trim_dagSwapTo_USDT2ETH_2trim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 1toCommission
+    function test_trim_dagSwapTo_USDT2ETH_1trimOnlyTrim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 1toCommission
+    function test_trim_dagSwapTo_USDT2ETH_1trimOnlyCharge_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 1toCommission
+    function test_trim_dagSwapTo_USDT2ETH_2trim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 2toCommission
+    function test_trim_dagSwapTo_USDT2ETH_1trimOnlyTrim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 2toCommission
+    function test_trim_dagSwapTo_USDT2ETH_1trimOnlyCharge_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 2toCommission
+    function test_trim_dagSwapTo_USDT2ETH_2trim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ETH with 2trim and 2fromCommission
+    function test_trim_dagSwapTo_USDT2ETH_2trim_2fromCommission() tokenLogAndCheck(USDT, ETH, 2000 * 10 ** 6, true, true, true, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHDagSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateWETH2USDTDagSwapData() internal view returns (bytes memory) {
+        // baseRequest
+        DexRouter.BaseRequest memory baseRequest = _generateBaseRequest(WETH, USDT, oneEther);
+        // batches
+        DexRouter.RouterPath[] memory path = new DexRouter.RouterPath[](1);
+        path[0].mixAdapters = new address[](1);
+        path[0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        path[0].assetTo = new address[](1);
+        path[0].assetTo[0] = address(UniversalUniV3Adapter);
+        path[0].rawData = new uint256[](1);
+        path[0].rawData[0] = uint256(bytes32(abi.encodePacked(uint64(0x00), uint8(0), uint8(1), uint16(10000), address(WETH_USDT_UNIV3))));
+        path[0].extraData = new bytes[](1);
+        path[0].extraData[0] = abi.encode(0, abi.encode(WETH, USDT, 0));
+        path[0].fromToken = uint256(uint160(WETH));
+
+        return abi.encodeWithSelector(
+            DexRouter.dagSwapTo.selector,
+            0, arnaud, baseRequest, path
+        );
+    }
+
+    function _generateETH2USDTDagSwapData() internal view returns (bytes memory) {
+        // baseRequest
+        DexRouter.BaseRequest memory baseRequest = _generateBaseRequest(ETH, USDT, oneEther);
+        // batches
+        DexRouter.RouterPath[] memory path = new DexRouter.RouterPath[](1);
+        path[0].mixAdapters = new address[](1);
+        path[0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        path[0].assetTo = new address[](1);
+        path[0].assetTo[0] = address(UniversalUniV3Adapter);
+        path[0].rawData = new uint256[](1);
+        path[0].rawData[0] = uint256(bytes32(abi.encodePacked(uint64(0x00), uint8(0), uint8(1), uint16(10000), address(WETH_USDT_UNIV3))));
+        path[0].extraData = new bytes[](1);
+        path[0].extraData[0] = abi.encode(0, abi.encode(WETH, USDT, 0));
+        path[0].fromToken = uint256(uint160(WETH));
+
+        return abi.encodeWithSelector(
+            DexRouter.dagSwapTo.selector,
+            0, arnaud, baseRequest, path
+        );
+    }
+
+    function _generateUSDT2ETHDagSwapData() internal view returns (bytes memory) {
+        // baseRequest
+        DexRouter.BaseRequest memory baseRequest = _generateBaseRequest(USDT, ETH, 1000 * 10 ** 6);
+        // batches
+        DexRouter.RouterPath[] memory path = new DexRouter.RouterPath[](1);
+        path[0].mixAdapters = new address[](1);
+        path[0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        path[0].assetTo = new address[](1);
+        path[0].assetTo[0] = address(UniversalUniV3Adapter);
+        path[0].rawData = new uint256[](1);
+        path[0].rawData[0] = uint256(bytes32(abi.encodePacked(uint64(0x00), uint8(0), uint8(1), uint16(10000), address(WETH_USDT_UNIV3))));
+        path[0].rawData[0] = path[0].rawData[0] | 1 << 255;
+        path[0].extraData = new bytes[](1);
+        path[0].extraData[0] = abi.encode(0, abi.encode(USDT, WETH, 0));
+        path[0].fromToken = uint256(uint160(USDT));
+
+        return abi.encodeWithSelector(
+            DexRouter.dagSwapTo.selector,
+            0, arnaud, baseRequest, path
+        );
+    }
+}

--- a/test/dexRouter/trim/MultiCallTrimTest.t.sol
+++ b/test/dexRouter/trim/MultiCallTrimTest.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+contract MultiCall {
+    function multiCall(address[] calldata targets, uint256[] calldata values, bytes[] calldata datas) external payable {
+        for (uint256 i = 0; i < targets.length; i++) {
+            (bool success_, ) = targets[i].call{value: values[i]}(datas[i]);
+            require(success_, "call failed");
+        }
+    }
+}
+
+contract MultiCallTrimTest is TrimAndCommissionTestBase {
+    MultiCall multiCall;
+
+    modifier tokenLog() {
+        deal(arnaud, 5 * 10 ** 18);
+        console2.log("eth balance of arnaud before: %d", address(arnaud).balance);
+        console2.log("eth balance of referrer1: %d", address(referrerAddresses[0]).balance);
+        console2.log("eth balance of referrer2: %d", address(referrerAddresses[1]).balance);
+        console2.log("eth balance of trim: %d", address(trimAddress).balance);
+        console2.log("eth balance of charge: %d", address(chargeAddress).balance);
+        console2.log("USDT balance of arnaud: %d", IERC20(USDT).balanceOf(address(arnaud)));
+        console2.log("USDT balance of referrer1: %d", IERC20(USDT).balanceOf(address(referrerAddresses[0])));
+        console2.log("USDT balance of referrer2: %d", IERC20(USDT).balanceOf(address(referrerAddresses[1])));
+        console2.log("USDT balance of trim: %d", IERC20(USDT).balanceOf(address(trimAddress)));
+        console2.log("USDT balance of charge: %d", IERC20(USDT).balanceOf(address(chargeAddress)));
+        _;
+        console2.log("eth balance of arnaud after: %d", address(arnaud).balance);
+        console2.log("eth balance of referrer1 after: %d", address(referrerAddresses[0]).balance);
+        console2.log("eth balance of referrer2 after: %d", address(referrerAddresses[1]).balance);
+        console2.log("eth balance of trim after: %d", address(trimAddress).balance);
+        console2.log("eth balance of charge after: %d", address(chargeAddress).balance);
+        console2.log("USDT balance of arnaud after: %d", IERC20(USDT).balanceOf(address(arnaud)));
+        console2.log("USDT balance of referrer1 after: %d", IERC20(USDT).balanceOf(address(referrerAddresses[0])));
+        console2.log("USDT balance of referrer2 after: %d", IERC20(USDT).balanceOf(address(referrerAddresses[1])));
+        console2.log("USDT balance of trim after: %d", IERC20(USDT).balanceOf(address(trimAddress)));
+        console2.log("USDT balance of charge after: %d", IERC20(USDT).balanceOf(address(chargeAddress)));
+    }
+
+    function setUp() public override {
+        multiCall = new MultiCall();
+        super.setUp();
+    }
+
+    function test_multiCall() public tokenLog {
+        vm.startPrank(arnaud);
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory commissionData1 = _generate1CommissionData(true, ETH); // fromTokenCommission
+        bytes memory commissionData2 = _generate1CommissionData(false, USDT); // toTokenCommission
+        bytes memory trimData1 = _generate1TrimOnlyTrimData();
+        bytes memory trimData2 = _generate1TrimOnlyChargeData();
+        
+        address[] memory targets = new address[](3);
+        targets[0] = address(dexRouter);
+        targets[1] = address(dexRouter);
+        targets[2] = address(dexRouter);
+        uint256[] memory values = new uint256[](3);
+        values[0] = 1.2 * 10 ** 18;
+        values[1] = 1.2 * 10 ** 18;
+        values[2] = 1.2 * 10 ** 18;
+        bytes[] memory datas = new bytes[](3);
+        datas[0] = bytes.concat(swapData, commissionData1);
+        datas[1] = bytes.concat(swapData, trimData1, commissionData2);
+        datas[2] = bytes.concat(swapData, trimData2, commissionData1);
+
+        bytes memory allData = abi.encodeWithSelector(
+            MultiCall.multiCall.selector,
+            targets,
+            values,
+            datas
+        );
+
+        // log calldata
+        // console2.logBytes(allData);
+
+        (bool success, ) = address(multiCall).call{value: 5 * 10 ** 18}(allData);
+        require(success, "call failed");
+        vm.stopPrank();
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateETH2USDTSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(ETH, USDT, oneEther);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = oneEther;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_USDT_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(WETH, USDT, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(WETH));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        ); 
+    }
+}

--- a/test/dexRouter/trim/SmartSwapSendTx.s.sol
+++ b/test/dexRouter/trim/SmartSwapSendTx.s.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/test.sol";
+import "forge-std/console2.sol";
+
+import "@dex/DexRouter.sol";
+import "../common/CommissionHelper.t.sol";
+import "../common/TrimHelper.t.sol";
+
+// cmd: forge script src/tests/trim/SmartSwapSendTx.s.sol:SendTx -vvv (--broadcast)
+
+contract SendTx is Test, CommissionHelper, TrimHelper {
+    address deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+
+    struct SwapInfo {
+        uint256 orderId;
+        DexRouter.BaseRequest baseRequest;
+        uint256[] batchesAmount;
+        DexRouter.RouterPath[][] batches;
+        PMMLib.PMMSwapRequest[] extraData;
+    }
+
+    uint256 inputAmount = 0.00001 * 10 ** 18;
+    uint256 fromTokenCommissionAmount = 0.00001 * 10 ** 16 * 4;
+
+    address ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address WETH = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+    address USDC = 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d;
+    address UniversalUniV3Adapter = 0x7A7AD9aa93cd0A2D0255326E5Fb145CEc14997FF;
+    address WETH_USDC_UNIV3 = 0x6bcb0Ba386E9de0C29006e46B2f01f047cA1806E;
+    address dexRouter = 0xF4858d71e5d7D27e3F7270390Cd57545DcA35aa9;
+    address ownedAddress = 0x87689BCAe752592965F1dceC6d5b74E968Ea78b5;
+
+    function _generateETH2USDCSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest.fromToken = uint256(uint160(ETH));
+        swapInfo.baseRequest.toToken = USDC;
+        swapInfo.baseRequest.fromTokenAmount = inputAmount;
+        swapInfo.baseRequest.minReturnAmount = 0;
+        swapInfo.baseRequest.deadLine = block.timestamp + 1000;
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = inputAmount;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_USDC_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(WETH, USDC, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(WETH));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, deployer, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+
+    function run() public {
+        console2.log("deployer", deployer);
+
+        vm.createSelectFork(vm.envString("BSC_RPC_URL"));
+        vm.startBroadcast(deployer);
+        console2.log("block.chainID", block.chainid);
+        console2.log("inputAmount", inputAmount);
+
+        console2.log("deployer balance before", address(deployer).balance);
+        console2.log("ownedAddress balance before", address(ownedAddress).balance);
+        console2.log("deployer USDC balance before", IERC20(USDC).balanceOf(address(deployer)));
+        console2.log("ownedAddress USDC balance before", IERC20(USDC).balanceOf(address(ownedAddress)));
+
+        bytes memory swapData = _generateETH2USDCSmartSwapData();
+        uint256[] memory commissionRates = new uint256[](2);
+        commissionRates[0] = 10000000;
+        commissionRates[1] = 20000000;
+        address[] memory referrerAddresses = new address[](2);
+        referrerAddresses[0] = ownedAddress;
+        referrerAddresses[1] = deployer;
+        bytes memory commissionData = _buildCommissionInfoUnified(
+            true, // isFromTokenCommission
+            false, // isToBCommission
+            ETH, // commissionToken
+            true, // isToBCommission
+            commissionRates,
+            referrerAddresses
+        );
+        bytes memory trimData = _buildTrimInfoUnified(
+            100, // trimRate
+            ownedAddress, // trimAddress
+            2000, // expectAmountOut
+            300, // chargeRate
+            deployer, // chargeAddress,
+            true // isToBTrim
+        );
+        bytes memory data = bytes.concat(swapData, trimData, commissionData); /// @notice the trimData should be before the commissionData
+        (bool success, ) = address(dexRouter).call{
+            value: inputAmount + fromTokenCommissionAmount /// @notice if commission is not used or toTokenCommission, the value shouldn't add fromTokenCommissionAmount
+        }(data);
+        require(success, "call failed");
+
+        console2.log("deployer balance after", address(deployer).balance);
+        console2.log("ownedAddress balance after", address(ownedAddress).balance);
+        console2.log("deployer USDC balance after", IERC20(USDC).balanceOf(address(deployer)));
+        console2.log("ownedAddress USDC balance after", IERC20(USDC).balanceOf(address(ownedAddress)));
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/dexRouter/trim/SmartSwapTrimTest.t.sol
+++ b/test/dexRouter/trim/SmartSwapTrimTest.t.sol
@@ -1,0 +1,724 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+/*
+ * The smartSwap method is tested with condition1 * condition2 + condition3 * condition4:
+ * condition1:
+ *     (1) ERC20 -> ERC20
+ *     (2) ETH -> ERC20
+ *     (3) ERC20 -> ETH
+ * condition2:
+ *     (1) noTrim + noCommission
+ *     (2) 1trimOnlyTrim + noCommission
+ *     (3) 1trimOnlyCharge + noCommission
+ *     (4) 2trim + noCommission
+ *     (5) 1trimOnlyTrim + 1toCommission
+ *     (6) 1trimOnlyCharge + 1toCommission
+ *     (7) 2trim + 1toCommission
+ *     (8) 1trimOnlyTrim + 2toCommission
+ *     (9) 1trimOnlyCharge + 2toCommission
+ *     (10) 2trim + 2toCommission
+ *     (11) 2trim + 2fromCommission
+ * condition3:
+ *     (1) ERC20 -> TaxToken(SAFEMOON)
+ *     (2) TaxToken(SAFEMOON) -> ERC20
+ * condition4:
+ *     (1) noTrim + noCommission
+ *     (2) noTrim + 2fromCommission
+ *     (3) notrim + 2toCommission
+ *     (4) 2trim + noCommission
+ *     (5) 2trim + 2fromCommission
+ *     (6) 2trim + 2toCommission
+*/
+contract SmartSwapTrimTest is TrimAndCommissionTestBase {
+    // ==================== ERC20->ERC20 ====================
+    // WETH->USDT with noTrim and noCommission
+    function test_trim_smartSwapTo_WETH2USDT_noTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 1trimOnlyTrim and noCommission
+    function test_trim_smartSwapTo_WETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 1trimOnlyCharge and noCommission
+    function test_trim_smartSwapTo_WETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 2trim and noCommission
+    function test_trim_smartSwapTo_WETH2USDT_2trim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 1trimOnlyTrim and 1toCommission
+    function test_trim_smartSwapTo_WETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 1trimOnlyCharge and 1toCommission
+    function test_trim_smartSwapTo_WETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 2trim and 1toCommission
+    function test_trim_smartSwapTo_WETH2USDT_2trim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 1trimOnlyTrim and 2toCommission
+    function test_trim_smartSwapTo_WETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 1trimOnlyCharge and 2toCommission
+    function test_trim_smartSwapTo_WETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // WETH->USDT with 2trim and 2toCommission
+    function test_trim_smartSwapTo_WETH2USDT_2trim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // WETH->USDT with 2trim and 2fromCommission
+    function test_trim_smartSwapTo_WETH2USDT_2trim_2fromCommission() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateWETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 1trimOnlyTrim and noCommission
+    function test_trim_smartSwapTo_USDT2WETH_1trimOnlyTrim_noCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, true, false, false, false, false) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 1trimOnlyCharge and noCommission
+    function test_trim_smartSwapTo_USDT2WETH_1trimOnlyCharge_noCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, false, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 2trim and noCommission
+    function test_trim_smartSwapTo_USDT2WETH_2trim_noCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, true, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 1trimOnlyTrim and 1toCommission
+    function test_trim_smartSwapTo_USDT2WETH_1trimOnlyTrim_1toCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, true, false, false, true, false) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 1trimOnlyCharge and 1toCommission
+    function test_trim_smartSwapTo_USDT2WETH_1trimOnlyCharge_1toCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, false, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 2trim and 1toCommission
+    function test_trim_smartSwapTo_USDT2WETH_2trim_1toCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, true, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 1trimOnlyTrim and 2toCommission
+    function test_trim_smartSwapTo_USDT2WETH_1trimOnlyTrim_2toCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, true, false, false, true, true) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 1trimOnlyCharge and 2toCommission
+    function test_trim_smartSwapTo_USDT2WETH_1trimOnlyCharge_2toCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, false, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // USDT->WETH with 2trim and 2toCommission
+    function test_trim_smartSwapTo_USDT2WETH_2trim_2toCommission() tokenLogAndCheck(USDT, WETH, 1000 * 10 ** 6, true, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // USDT->WETH with 2trim and 2fromCommission
+    function test_trim_smartSwapTo_USDT2WETH_2trim_2fromCommission() tokenLogAndCheck(USDT, WETH, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateUSDT2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ETH->ERC20 ====================
+    // ETH->ERC20 with noTrim and noCommission
+    function test_trim_smartSwapTo_ETH2USDT_noTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        (bool success, ) = address(dexRouter).call{value: oneEther}(swapData);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_smartSwapTo_ETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_smartSwapTo_ETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and noCommission
+    function test_trim_smartSwapTo_ETH2USDT_2trim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_smartSwapTo_ETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_smartSwapTo_ETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 1toCommission
+    function test_trim_smartSwapTo_ETH2USDT_2trim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_smartSwapTo_ETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_smartSwapTo_ETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 2toCommission
+    function test_trim_smartSwapTo_ETH2USDT_2trim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+    
+    // ETH->ERC20 with 2trim and 2fromCommission
+    function test_trim_smartSwapTo_ETH2USDT_2trim_2fromCommission() tokenLogAndCheck(ETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateETH2USDTSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ERC20->ETH ====================
+    // ERC20->ETH with noTrim and noCommission
+    function test_trim_smartSwapTo_USDT2ETH_noTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, false, false, false, false)  public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and noCommission
+    function test_trim_smartSwapTo_USDT2ETH_1trimOnlyTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and noCommission
+    function test_trim_smartSwapTo_USDT2ETH_1trimOnlyCharge_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and noCommission
+    function test_trim_smartSwapTo_USDT2ETH_2trim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 1toCommission
+    function test_trim_smartSwapTo_USDT2ETH_1trimOnlyTrim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 1toCommission
+    function test_trim_smartSwapTo_USDT2ETH_1trimOnlyCharge_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 1toCommission
+    function test_trim_smartSwapTo_USDT2ETH_2trim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 2toCommission
+    function test_trim_smartSwapTo_USDT2ETH_1trimOnlyTrim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 2toCommission
+    function test_trim_smartSwapTo_USDT2ETH_1trimOnlyCharge_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 2toCommission
+    function test_trim_smartSwapTo_USDT2ETH_2trim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ETH with 2trim and 2fromCommission
+    function test_trim_smartSwapTo_USDT2ETH_2trim_2fromCommission() tokenLogAndCheck(USDT, ETH, 2000 * 10 ** 6, true, true, true, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ================= ERC20->TaxToken(SAFEMOON) ================
+    // ERC20->TaxToken(SAFEMOON) with noTrim and noCommission
+    function test_trim_smartSwapTo_WETH2SAFEMOON_noTrim_noCommission() tokenLogAndCheck(WETH, SAFEMOON, 0.01 * 10 ** 18, false, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->TaxToken(SAFEMOON) with noTrim and 2fromCommission
+    function test_trim_smartSwapTo_WETH2SAFEMOON_noTrim_2fromCommission() tokenLogAndCheck(WETH, SAFEMOON, 0.02 * 10 ** 18, false, false, true, true, true) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generate2CommissionData(true, WETH);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->TaxToken(SAFEMOON) with noTrim and 2toCommission
+    function test_trim_smartSwapTo_WETH2SAFEMOON_noTrim_2toCommission() tokenLogAndCheck(WETH, SAFEMOON, 0.01 * 10 ** 18, false, false, false, true, true) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory commissionData = _generate2CommissionData(false, SAFEMOON);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->TaxToken(SAFEMOON) with 2trim and noCommission
+    function test_trim_smartSwapTo_WETH2SAFEMOON_2trim_noCommission() tokenLogAndCheck(WETH, SAFEMOON, 0.01 * 10 ** 18, true, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->TaxToken(SAFEMOON) with 2trim and 2fromCommission
+    function test_trim_smartSwapTo_WETH2SAFEMOON_2trim_2fromCommission() tokenLogAndCheck(WETH, SAFEMOON, 0.02 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->TaxToken(SAFEMOON) with 2trim and 2toCommission
+    function test_trim_smartSwapTo_WETH2SAFEMOON_2trim_2toCommission() tokenLogAndCheck(WETH, SAFEMOON, 0.01 * 10 ** 18, true, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2SAFEMOONSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, SAFEMOON);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== TaxToken(SAFEMOON)->ERC20 ====================
+    // TaxToken(SAFEMOON)->ERC20 with noTrim and noCommission
+    function test_trim_smartSwapTo_SAFEMOON2WETH_noTrim_noCommission() tokenLogAndCheck(SAFEMOON, WETH, 1 * 10 ** 27, false, false, false, false, false) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // TaxToken(SAFEMOON)->ERC20 with noTrim and 2fromCommission
+    function test_trim_smartSwapTo_SAFEMOON2WETH_noTrim_2fromCommission() tokenLogAndCheck(SAFEMOON, WETH, 2 * 10 ** 27, false, false, true, true, true) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generate2CommissionData(true, SAFEMOON);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // TaxToken(SAFEMOON)->ERC20 with noTrim and 2toCommission
+    function test_trim_smartSwapTo_SAFEMOON2WETH_noTrim_2toCommission() tokenLogAndCheck(SAFEMOON, WETH, 1 * 10 ** 27, false, false, false, true, true) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory commissionData = _generate2CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // TaxToken(SAFEMOON)->ERC20 with 2trim and noCommission
+    function test_trim_smartSwapTo_SAFEMOON2WETH_2trim_noCommission() tokenLogAndCheck(SAFEMOON, WETH, 1 * 10 ** 27, true, true, false, false, false) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // TaxToken(SAFEMOON)->ERC20 with 2trim and 2fromCommission
+    function test_trim_smartSwapTo_SAFEMOON2WETH_2trim_2fromCommission() tokenLogAndCheck(SAFEMOON, WETH, 2 * 10 ** 27, true, true, true, true, true) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, SAFEMOON);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // TaxToken(SAFEMOON)->ERC20 with 2trim and 2toCommission
+    function test_trim_smartSwapTo_SAFEMOON2WETH_2trim_2toCommission() tokenLogAndCheck(SAFEMOON, WETH, 1 * 10 ** 27, true, true, false, true, true) public {
+        bytes memory swapData = _generateSAFEMOON2WETHSmartSwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateWETH2USDTSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(WETH, USDT, oneEther);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = oneEther;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_USDT_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(WETH, USDT, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(WETH));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+
+    function _generateUSDT2WETHSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(USDT, WETH, oneEther);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = 1000 * 10 ** 6;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_USDT_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(USDT, WETH, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(USDT));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+
+    function _generateETH2USDTSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(ETH, USDT, oneEther);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = oneEther;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_USDT_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(WETH, USDT, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(WETH));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        ); 
+    }
+
+    function _generateUSDT2ETHSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(USDT, ETH, 1000 * 10 ** 6);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = 1000 * 10 ** 6;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(UniversalUniV3Adapter);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x80), uint88(10000), address(WETH_USDT_UNIV3))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].extraData[0] = abi.encode(0, abi.encode(USDT, WETH, 0));
+        swapInfo.batches[0][0].fromToken = uint256(uint160(USDT));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        ); 
+    }
+
+    function _generateWETH2SAFEMOONSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(WETH, SAFEMOON, 0.01 * 10 ** 18);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = 0.01 * 10 ** 18;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniV2Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(WETH_SAFEMOON_UNIV2);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint88(10000), address(WETH_SAFEMOON_UNIV2))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].fromToken = uint256(uint160(WETH));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+
+    function _generateSAFEMOON2WETHSmartSwapData() internal view returns (bytes memory) {
+        SwapInfo memory swapInfo;
+        // baseRequest
+        swapInfo.baseRequest = _generateBaseRequest(SAFEMOON, WETH, 1 * 10 ** 27);
+        // batchesAmount
+        swapInfo.batchesAmount = new uint256[](1);
+        swapInfo.batchesAmount[0] = 1 * 10 ** 27;
+        // batches
+        swapInfo.batches = new DexRouter.RouterPath[][](1);
+        swapInfo.batches[0] = new DexRouter.RouterPath[](1);
+        swapInfo.batches[0][0].mixAdapters = new address[](1);
+        swapInfo.batches[0][0].mixAdapters[0] = address(UniV2Adapter);
+        swapInfo.batches[0][0].assetTo = new address[](1);
+        swapInfo.batches[0][0].assetTo[0] = address(WETH_SAFEMOON_UNIV2);
+        swapInfo.batches[0][0].rawData = new uint256[](1);
+        swapInfo.batches[0][0].rawData[0] = uint256(bytes32(abi.encodePacked(uint8(0x80), uint88(10000), address(WETH_SAFEMOON_UNIV2))));
+        swapInfo.batches[0][0].extraData = new bytes[](1);
+        swapInfo.batches[0][0].fromToken = uint256(uint160(SAFEMOON));
+        // extraData
+        swapInfo.extraData = new PMMLib.PMMSwapRequest[](0);
+
+        return abi.encodeWithSelector(
+            DexRouter.smartSwapTo.selector,
+            swapInfo.orderId, arnaud, swapInfo.baseRequest, swapInfo.batchesAmount, swapInfo.batches, swapInfo.extraData
+        );
+    }
+}

--- a/test/dexRouter/trim/UniswapV3SwapTrimTest.t.sol
+++ b/test/dexRouter/trim/UniswapV3SwapTrimTest.t.sol
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+/*
+ * The uniswapV3Swap method is tested with condition1 * condition2:
+ * condition1:
+ *     (1) ERC20 -> ERC20
+ *     (2) ETH -> ERC20
+ *     (3) ERC20 -> ETH
+ * condition2:
+ *     (1) noTrim + noCommission
+ *     (2) 1trimOnlyTrim + noCommission
+ *     (3) 1trimOnlyCharge + noCommission
+ *     (4) 2trim + noCommission
+ *     (5) 1trimOnlyTrim + 1toCommission
+ *     (6) 1trimOnlyCharge + 1toCommission
+ *     (7) 2trim + 1toCommission
+ *     (8) 1trimOnlyTrim + 2toCommission
+ *     (9) 1trimOnlyCharge + 2toCommission
+ *     (10) 2trim + 2toCommission
+ *     (11) 2trim + 2fromCommission
+*/
+contract UniswapV3SwapTrimTest is TrimAndCommissionTestBase {
+
+    // ==================== ERC20->ERC20 ====================
+    // ERC20->ERC20 with noTrim and noCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_noTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and noCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and noCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_2trim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and 1toCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_2trim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and 2toCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_2trim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ERC20 with 2trim and 2fromCommission
+    function test_trim_uniswapV3SwapTo_WETH2USDT_2trim_2fromCommission() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ETH->ERC20 ====================
+    // ETH->ERC20 with noTrim and noCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_noTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        (bool success, ) = address(dexRouter).call{value: oneEther}(swapData);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and noCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and noCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_2trim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 1toCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_2trim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 2toCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_2trim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+    
+    // ETH->ERC20 with 2trim and 2fromCommission
+    function test_trim_uniswapV3SwapTo_ETH2USDT_2trim_2fromCommission() tokenLogAndCheck(ETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ERC20->ETH ====================
+    // ERC20->ETH with noTrim and noCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_noTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, false, false, false, false)  public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and noCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_1trimOnlyTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and noCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_1trimOnlyCharge_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and noCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_2trim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 1toCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_1trimOnlyTrim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 1toCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_1trimOnlyCharge_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 1toCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_2trim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 2toCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_1trimOnlyTrim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 2toCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_1trimOnlyCharge_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 2toCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_2trim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ETH with 2trim and 2fromCommission
+    function test_trim_uniswapV3SwapTo_USDT2ETH_2trim_2fromCommission() tokenLogAndCheck(USDT, ETH, 2000 * 10 ** 6, true, true, true, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUniswapV3SwapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateWETH2USDTUniswapV3SwapData() internal view returns (bytes memory) {
+        uint256 receiver = uint256(uint160(arnaud));
+        uint256 amount = oneEther;
+        uint256 minReturn = 0;
+        uint256[] memory pools = new uint256[](1);
+        pools[0] = uint256(bytes32(abi.encodePacked(uint8(0x00), uint56(0), uint32(amount), address(WETH_USDT_UNIV3))));
+        return abi.encodeWithSelector(
+            DexRouter.uniswapV3SwapTo.selector, receiver, amount, minReturn, pools
+        );
+    }
+
+    function _generateUSDT2ETHUniswapV3SwapData() internal view returns (bytes memory) {
+        uint256 receiver = uint256(uint160(arnaud));
+        uint256 amount = 1000 * 10 ** 6;
+        uint256 minReturn = 0;
+        uint256[] memory pools = new uint256[](1);
+        pools[0] = uint256(bytes32(abi.encodePacked(uint8(0xa0), uint56(0), uint32(amount), address(WETH_USDT_UNIV3))));
+        return abi.encodeWithSelector(
+            DexRouter.uniswapV3SwapTo.selector, receiver, amount, minReturn, pools
+        );
+    }
+}

--- a/test/dexRouter/trim/UnxswapTrimTest.t.sol
+++ b/test/dexRouter/trim/UnxswapTrimTest.t.sol
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../common/TrimAndCommissionTestBase.t.sol";
+
+/*
+ * The unxswap method is tested with condition1 * condition2:
+ * condition1:
+ *     (1) ERC20 -> ERC20
+ *     (2) ETH -> ERC20
+ *     (3) ERC20 -> ETH
+ * condition2:
+ *     (1) noTrim + noCommission
+ *     (2) 1trimOnlyTrim + noCommission
+ *     (3) 1trimOnlyCharge + noCommission
+ *     (4) 2trim + noCommission
+ *     (5) 1trimOnlyTrim + 1toCommission
+ *     (6) 1trimOnlyCharge + 1toCommission
+ *     (7) 2trim + 1toCommission
+ *     (8) 1trimOnlyTrim + 2toCommission
+ *     (9) 1trimOnlyCharge + 2toCommission
+ *     (10) 2trim + 2toCommission
+ *     (11) 2trim + 2fromCommission
+*/
+contract UnxswapTrimTest is TrimAndCommissionTestBase {
+
+    // ==================== ERC20->ERC20 ====================
+    // ERC20->ERC20 with noTrim and noCommission
+    function test_trim_unxswapTo_WETH2USDT_noTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_unxswapTo_WETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and noCommission
+    function test_trim_unxswapTo_WETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and noCommission
+    function test_trim_unxswapTo_WETH2USDT_2trim_noCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_unxswapTo_WETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_unxswapTo_WETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and 1toCommission
+    function test_trim_unxswapTo_WETH2USDT_2trim_1toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_unxswapTo_WETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_unxswapTo_WETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ERC20 with 2trim and 2toCommission
+    function test_trim_unxswapTo_WETH2USDT_2trim_2toCommission() tokenLogAndCheck(WETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ERC20 with 2trim and 2fromCommission
+    function test_trim_unxswapTo_WETH2USDT_2trim_2fromCommission() tokenLogAndCheck(WETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateWETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, WETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ETH->ERC20 ====================
+    // ETH->ERC20 with noTrim and noCommission
+    function test_trim_unxswapTo_ETH2USDT_noTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, false, false, false, false)  public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        (bool success, ) = address(dexRouter).call{value: oneEther}(swapData);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and noCommission
+    function test_trim_unxswapTo_ETH2USDT_1trimOnlyTrim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and noCommission
+    function test_trim_unxswapTo_ETH2USDT_1trimOnlyCharge_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and noCommission
+    function test_trim_unxswapTo_ETH2USDT_2trim_noCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, false, false) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 1toCommission
+    function test_trim_unxswapTo_ETH2USDT_1trimOnlyTrim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 1toCommission
+    function test_trim_unxswapTo_ETH2USDT_1trimOnlyCharge_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 1toCommission
+    function test_trim_unxswapTo_ETH2USDT_2trim_1toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, false) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyTrim and 2toCommission
+    function test_trim_unxswapTo_ETH2USDT_1trimOnlyTrim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, false, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 1trimOnlyCharge and 2toCommission
+    function test_trim_unxswapTo_ETH2USDT_1trimOnlyCharge_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, false, true, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 2toCommission
+    function test_trim_unxswapTo_ETH2USDT_2trim_2toCommission() tokenLogAndCheck(ETH, USDT, oneEther, true, true, false, true, true) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: oneEther}(data);
+        require(success, "call failed");
+    }
+    
+    // ETH->ERC20 with 2trim and 2fromCommission
+    function test_trim_unxswapTo_ETH2USDT_2trim_2fromCommission() tokenLogAndCheck(ETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // ETH->ERC20 with 2trim and 2fromCommission
+    function test_trim_unxswapTo_ETH2USDT_2trim_2fromCommission_ETHisAddressE() tokenLogAndCheck(ETH, USDT, 2 * 10 ** 18, true, true, true, true, true) public {
+        bytes memory swapData = _generateETH2USDTUnxswapData2();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call{value: 2 * 10 ** 18}(data);
+        require(success, "call failed");
+    }
+
+    // ==================== ERC20->ETH ====================
+    // ERC20->ETH with noTrim and noCommission
+    function test_trim_unxswapTo_USDT2ETH_noTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, false, false, false, false)  public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        (bool success, ) = address(dexRouter).call(swapData);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and noCommission
+    function test_trim_unxswapTo_USDT2ETH_1trimOnlyTrim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and noCommission
+    function test_trim_unxswapTo_USDT2ETH_1trimOnlyCharge_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and noCommission
+    function test_trim_unxswapTo_USDT2ETH_2trim_noCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, false, false) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory data = bytes.concat(swapData, trimData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 1toCommission
+    function test_trim_unxswapTo_USDT2ETH_1trimOnlyTrim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 1toCommission
+    function test_trim_unxswapTo_USDT2ETH_1trimOnlyCharge_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 1toCommission
+    function test_trim_unxswapTo_USDT2ETH_2trim_1toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, false) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate1CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyTrim and 2toCommission
+    function test_trim_unxswapTo_USDT2ETH_1trimOnlyTrim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, false, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyTrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 1trimOnlyCharge and 2toCommission
+    function test_trim_unxswapTo_USDT2ETH_1trimOnlyCharge_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, false, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate1TrimOnlyChargeData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ERC20->ETH with 2trim and 2toCommission
+    function test_trim_unxswapTo_USDT2ETH_2trim_2toCommission() tokenLogAndCheck(USDT, ETH, 1000 * 10 ** 6, true, true, false, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(false, ETH);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+    
+    // ERC20->ETH with 2trim and 2fromCommission
+    function test_trim_unxswapTo_USDT2ETH_2trim_2fromCommission() tokenLogAndCheck(USDT, ETH, 2000 * 10 ** 6, true, true, true, true, true) public {
+        bytes memory swapData = _generateUSDT2ETHUnxswapData();
+        bytes memory trimData = _generate2TrimData();
+        bytes memory commissionData = _generate2CommissionData(true, USDT);
+        bytes memory data = bytes.concat(swapData, trimData, commissionData);
+        (bool success, ) = address(dexRouter).call(data);
+        require(success, "call failed");
+    }
+
+    // ==================== Internal Functions ====================
+    function _generateWETH2USDTUnxswapData() internal view returns (bytes memory) {
+        uint256 srcToken = uint256(uint160(WETH));
+        uint256 amount = oneEther;
+        uint256 minReturn = 0;
+        address receiver = arnaud;
+        bytes32[] memory pools = new bytes32[](1);
+        pools[0] = bytes32(abi.encodePacked(uint8(0x00), uint56(0), uint32(amount * 996 / 1000), address(WETH_USDT_UNIV2)));
+        return abi.encodeWithSelector(
+            DexRouter.unxswapTo.selector, srcToken, amount, minReturn, receiver, pools
+        );
+    }
+
+    function _generateETH2USDTUnxswapData() internal view returns (bytes memory) {
+        uint256 srcToken = 123 << 160;
+        uint256 amount = oneEther;
+        uint256 minReturn = 0;
+        address receiver = arnaud;
+        bytes32[] memory pools = new bytes32[](1);
+        pools[0] = bytes32(abi.encodePacked(uint8(0x00), uint56(0), uint32(amount * 996 / 1000), address(WETH_USDT_UNIV2)));
+        return abi.encodeWithSelector(
+            DexRouter.unxswapTo.selector, srcToken, amount, minReturn, receiver, pools
+        );
+    }
+
+    function _generateETH2USDTUnxswapData2() internal view returns (bytes memory) {
+        uint256 srcToken = 456 << 160 | uint256(uint160(ETH));
+        uint256 amount = oneEther;
+        uint256 minReturn = 0;
+        address receiver = arnaud;
+        bytes32[] memory pools = new bytes32[](1);
+        pools[0] = bytes32(abi.encodePacked(uint8(0x00), uint56(0), uint32(amount * 996 / 1000), address(WETH_USDT_UNIV2)));
+        return abi.encodeWithSelector(
+            DexRouter.unxswapTo.selector, srcToken, amount, minReturn, receiver, pools
+        );
+    }
+
+    function _generateUSDT2ETHUnxswapData() internal view returns (bytes memory) {
+        uint256 srcToken = uint256(uint160(USDT));
+        uint256 amount = 1000 * 10 ** 6;
+        uint256 minReturn = 0;
+        address receiver = arnaud;
+        bytes32[] memory pools = new bytes32[](1);
+        pools[0] = bytes32(abi.encodePacked(uint8(0xc0), uint56(0), uint32(amount * 996 / 1000), address(WETH_USDT_UNIV2)));
+        return abi.encodeWithSelector(
+            DexRouter.unxswapTo.selector, srcToken, amount, minReturn, receiver, pools
+        );
+    }
+}


### PR DESCRIPTION
# Multi-Commission and Enhanced Trim Functionality

## Overview

This document describes the implementation of the multi-commission system and enhanced trim functionality for the DEX Router. This feature extends the router's capability to support up to 8 referrers per transaction and introduces advanced fee distribution mechanisms.

## 🚀 Features

### Multi-Commission System

The new multi-commission system supports three types of commission structures:

1. **Single Commission** (1 referrer)
2. **Dual Commission** (2 referrers) 
3. **Multiple Commission** (3-8 referrers)

#### Commission Types

- **From Token Commission**: Commission taken from the input token
- **To Token Commission**: Commission taken from the output token
- **ToB Commission**: Business-oriented commission with enhanced distribution logic

### Enhanced Trim Functionality

The trim system has been enhanced with:

- **ToB Trim Support**: Business-oriented trim functionality
- **Flexible Trim Configuration**: Support for trim-only, charge-only, and combined operations
- **Improved Distribution Logic**: Enhanced calculation and distribution mechanisms

## 📋 Technical Specifications

### Data Structures

#### CommissionInfo Struct

```solidity
struct CommissionInfo {
    bool isFromTokenCommission;     // 0x00
    bool isToTokenCommission;       // 0x20
    address token;                  // 0x40
    uint256 toBCommission;          // 0x60 - 0: no commission, 1: no-toB, 2: toB
    uint256 commissionLength;       // 0x80 - Number of referrers (1-8)
    uint256 commissionRate;         // 0xa0 - First referrer rate
    address referrerAddress;        // 0xc0 - First referrer address
    uint256 commissionRate2;        // 0xe0 - Second referrer rate
    address referrerAddress2;       // 0x100 - Second referrer address
    // ... up to 8 referrers (commissionRate8, referrerAddress8)
}
```

#### TrimInfo Struct

```solidity
struct TrimInfo {
    bool hasTrim;                   // 0x00
    uint256 trimRate;              // 0x20
    address trimAddress;           // 0x40
    uint256 toBTrim;               // 0x60 - 0: no trim, 1: no-toB, 2: toB
    uint256 expectAmountOut;       // 0x80
    uint256 chargeRate;            // 0xa0
    address chargeAddress;         // 0xc0
}
```

### Commission Encoding Format

#### Single Commission
```
┌──────────────────────────────────────────┬──────────────────────────────────────────┐
│            2nd bytes32                   │              1st bytes32                 │
│      (isToB + padding + token_addr)      │      (flag + rate + referer_addr)        │
├────────┬──────────────────┬──────────────┼─────────────┬─────────────┬──────────────┤
│ isToB  │     padding      │token_address │    flag     │    rate     │referer_addr  │
│ 1 byte │    11 bytes      │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │
└────────┴──────────────────┴──────────────┴─────────────┴─────────────┴──────────────┘
```

#### Multiple Commission (3-8 referrers)
```
┌────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────┐
│            │            4th bytes32                   │            3rd bytes32                   │            2nd bytes32                   │             1st bytes32                  │
│            │      (flag + rate3 + referer_addr3)      │      (flag + rate2 + referer_addr2)      │      (isToB + padding + token_addr)      │      (flag + rate1 + referer_addr1)      │
│ Maybe      ├─────────────┬─────────────┬──────────────┼─────────────┬─────────────┬──────────────┼────────┬───────┬──────────┬──────────────┼─────────────┬─────────────┬──────────────┤
│ more       │    flag     │   rate3     │referer_addr3 │    flag     │   rate2     │referer_addr2 │ isToB  │padding|referrer_num│token_address│    flag    │   rate1     │referer_addr1 │
│ commission │   6 bytes   │   6 bytes   │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │ 1 byte │10bytes|  1 byte  │   20 bytes   │   6 bytes   │   6 bytes   │   20 bytes   │
└────────────┴─────────────┴─────────────┴──────────────┴─────────────┴─────────────┴──────────────┴────────┴──────────────────┴──────────────┴─────────────┴─────────────┴──────────────┘
```

## 🔧 Implementation Details

### Core Files Modified

#### Contracts
- `contracts/8/interfaces/AbstractCommissionLib.sol` - Extended data structures
- `contracts/8/libraries/CommissionLib.sol` - Enhanced commission processing logic
- `contracts/8/DexRouter.sol` - Updated router implementation
- `contracts/8/DagRouter.sol` - Enhanced DAG router functionality

#### Test Infrastructure
- `test/dexRouter/common/CommissionHelper.t.sol` - Commission utilities
- `test/dexRouter/common/TrimAndCommissionTestBase.t.sol` - Base test contract
- `test/dexRouter/common/TrimHelper.t.sol` - Trim utilities
- `test/dexRouter/multiCommission/SmartSwapMultiCommissionTest.t.sol` - Comprehensive test suite
- `test/dexRouter/trim/` - Complete trim test directory

### Commission Flags

```solidity
uint256 internal constant FROM_TOKEN_COMMISSION = 0x3ca20afc2aaa0000000000000000000000000000000000000000000000000000;
uint256 internal constant TO_TOKEN_COMMISSION = 0x3ca20afc2bbb0000000000000000000000000000000000000000000000000000;
uint256 internal constant FROM_TOKEN_COMMISSION_DUAL = 0x22220afc2aaa0000000000000000000000000000000000000000000000000000;
uint256 internal constant TO_TOKEN_COMMISSION_DUAL = 0x22220afc2bbb0000000000000000000000000000000000000000000000000000;
uint256 internal constant FROM_TOKEN_COMMISSION_MULTIPLE = 0x88880afc2aaa0000000000000000000000000000000000000000000000000000;
uint256 internal constant TO_TOKEN_COMMISSION_MULTIPLE = 0x88880afc2bbb0000000000000000000000000000000000000000000000000000;
```

### Validation Rules

1. **Commission Length**: Must be between 1 and 8 referrers
2. **Mutual Exclusivity**: `isFromTokenCommission` and `isToTokenCommission` cannot both be true or false
3. **Paired Values**: Commission rates and referrer addresses must be set/unset together
4. **Rate Limits**: Commission rates must be within acceptable bounds

## 🧪 Test Coverage

### Test Scenarios

The test suite covers **80+ scenarios** including:

#### Token Pairs
- **ERC20 ↔ ERC20**: WETH ↔ USDT, USDT ↔ WETH
- **ETH ↔ ERC20**: ETH ↔ USDT, USDT ↔ ETH  
- **Tax Tokens**: WETH ↔ SAFEMOON, SAFEMOON ↔ WETH

#### Commission Configurations
- **3 referrers** + various trim combinations
- **8 referrers** + various trim combinations
- **ToB Commission** variants

#### Trim Configurations
- **No Trim**: Commission only
- **Trim Only**: 5% trim rate, no charge
- **Charge Only**: 5% trim rate, 100% to charge
- **Combined Trim**: 5% trim rate, 40% to charge, 60% to trim

### Test Structure

```solidity
function test_multiCommission_smartSwapTo_WETH2USDT_8fromCommission_noTrim() 
    tokenLogAndCheck2(WETH, USDT, 2 * 10 ** 18, false, false, true, 8) 
    public 
{
    bytes memory swapData = _generateWETH2USDTSmartSwapData();
    bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
    bytes memory data = bytes.concat(swapData, commissionData);
    (bool success, ) = address(dexRouter).call(data);
    require(success, "call failed");
}
```

## 📚 Usage Examples

### Building Commission Data

```solidity
// Single commission
uint256[] memory rates = new uint256[](1);
rates[0] = 1000000; // 1% commission rate

address[] memory referrers = new address[](1);
referrers[0] = 0x1234567890123456789012345678901234567890;

bytes memory commissionData = _buildCommissionInfoUnified(
    true,        // isFromTokenCommission
    false,       // isToTokenCommission  
    WETH,        // token
    false,       // isToBCommission
    rates,       // commission rates
    referrers    // referrer addresses
);
```

### Building Trim Data

```solidity
bytes memory trimData = _buildTrimInfoUnified(
    50,              // trimRate (5%)
    trimAddress,     // trimAddress
    100,             // expectAmountOut
    400,             // chargeRate (40% of trim)
    chargeAddress,   // chargeAddress
    true             // isToBTrim
);
```

### Smart Swap with Multi-Commission

```solidity
bytes memory swapData = _generateSmartSwapData(...);
bytes memory commissionData = _generateMultipleCommissionData(true, WETH, false, 8);
bytes memory trimData = _generate2TrimData();
bytes memory data = bytes.concat(swapData, trimData, commissionData);

(bool success, ) = address(dexRouter).call(data);
```

## 🔄 Migration Guide

### From Previous Version

1. **Existing Implementations**: Single and dual commission implementations remain compatible
2. **New Features**: Multi-commission requires updated client integration
3. **Data Structure Changes**: Update any direct struct access to use new field names

### Integration Steps

1. **Update Contracts**: Deploy new router contracts with multi-commission support
2. **Update Client Code**: Implement new commission data building functions
3. **Test Integration**: Use provided test suite as reference implementation
4. **Gradual Rollout**: Start with single/dual commission, then expand to multi-commission

## ⚠️ Breaking Changes

1. **CommissionInfo Struct**: Extended with new fields for multi-referrer support
2. **TrimInfo Struct**: Added `toBTrim` field for enhanced trim functionality
3. **Encoding Format**: Multi-commission uses different encoding than single/dual
4. **Validation Rules**: Enhanced validation for commission parameters

## 🔍 Security Considerations

1. **Input Validation**: Comprehensive validation of commission parameters
2. **Rate Limits**: Commission rates are bounded to prevent excessive fees
3. **Address Validation**: Referrer addresses are validated for non-zero values
4. **Overflow Protection**: Safe math operations for all calculations

## 📊 Performance Impact

- **Gas Usage**: Minimal increase for single/dual commission, moderate increase for multi-commission
- **Storage**: Efficient packing of commission data in bytes32 chunks
- **Computation**: Optimized loops and bitwise operations for commission processing

## 🚀 Future Enhancements

1. **Dynamic Commission Rates**: Support for time-based or volume-based commission adjustments
2. **Commission Pools**: Shared commission pools for multiple transactions
3. **Advanced Trim Logic**: More sophisticated trim calculation algorithms
4. **Commission Analytics**: On-chain commission tracking and reporting

---

## 📞 Support

For questions or issues related to the multi-commission functionality:

1. Review the comprehensive test suite in `test/dexRouter/multiCommission/`
2. Check the helper utilities in `test/dexRouter/common/`
3. Refer to the trim functionality tests in `test/dexRouter/trim/`

## 📝 Changelog

### Added
- Multi-commission support for up to 8 referrers
- ToB commission and trim functionality
- Comprehensive test suite with 80+ scenarios
- Enhanced commission and trim helper utilities
- Improved data structure layouts

### Modified
- Extended CommissionInfo and TrimInfo structs
- Enhanced commission processing logic in CommissionLib
- Updated DexRouter and DagRouter implementations

### Deprecated
- None (backward compatibility maintained)

### Removed
- None

---

*This feature represents a significant enhancement to the DEX Router's commission capabilities while maintaining backward compatibility and providing extensive test coverage.*
